### PR TITLE
removing the directions about cpphs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,6 @@ Then, the usual setup steps apply:
 
 cabal sandbox init
 cabal configure
-cabal install cpphs //for some reason the thyme library won't find this dependency on its own
 cabal install --only-dependencies --enable-tests
 cabal build
 cabal test


### PR DESCRIPTION
Suggest removing this change for two reasons.  
1. I didn't run into this problem when I did a cabal sandbox init and cabal configure (forgot about that)
2. it messed up the formatting so all the lines ran together

if anyone else runs into this issue we should put it back with nicer formatting.

This also seemed like a reasonable place to mention another issue i ran into, but if you'd prefer it someplace else let me know.

I was able to run /scripts/create_user.sh successfully, but after doing so, I got a 500 when trying to run create_project.sh

```
 HTTP/1.1 500 Internal Server Error
< Content-Length: 226
* Server Snap/0.9.5.1 is not blacklisted
< Server: Snap/0.9.5.1
< Date: Wed, 27 May 2015 23:10:35 GMT
< Content-Type: text/plain; charset=utf-8
<
A web handler threw an exception. Details:
* Connection #0 to host localhost left intact
SqlError {sqlState = "42703", sqlExecStatus = FatalError, sqlErrorMsg = "column \"user_id\" of relation \"project_companions\" does not exist", sqlErrorDetail = "", sqlErrorHint = ""}
```

I didn't appear to have any errors when running any of the db initialization scripts. (other than the expected on that fails and then creates the config file to edit)
