### PR TITLE
Add GitHub PR time tracking via webhook integration

### DIFF
--- a/api/aftok-api.cabal
+++ b/api/aftok-api.cabal
@@ -41,6 +41,7 @@ library
     Aftok.API.Payments
     Aftok.API.PasswordReset
     Aftok.API.Config
+    Aftok.API.GitHub
     Aftok.API.OpenApi
 
   build-depends:

--- a/api/aftok-api.cabal
+++ b/api/aftok-api.cabal
@@ -29,6 +29,7 @@ library
   hs-source-dirs:     src
   exposed-modules:
     Aftok.API
+    Aftok.API.Codec
     Aftok.API.Types
     Aftok.API.Auth
     Aftok.API.Users
@@ -47,6 +48,8 @@ library
     relude >= 1.1.0 && < 1.3,
     aftok,
     aeson >= 2.0.3 && < 2.3,
+    autodocodec >= 0.4 && < 0.6,
+    autodocodec-openapi3 >= 0.2 && < 0.4,
     bytestring >= 0.11.4 && < 0.13,
     containers >= 0.6.5 && < 0.8,
     hourglass >= 0.2.12 && < 0.3,

--- a/api/src/Aftok/API.hs
+++ b/api/src/Aftok/API.hs
@@ -20,6 +20,7 @@ module Aftok.API
     module Aftok.API.Payments,
     module Aftok.API.PasswordReset,
     module Aftok.API.Config,
+    module Aftok.API.GitHub,
 
     -- * Auth Types
     module Aftok.API.Auth,
@@ -33,6 +34,7 @@ import Aftok.API.Auth
 import Aftok.API.Auctions
 import Aftok.API.Billing
 import Aftok.API.Config
+import Aftok.API.GitHub
 import Aftok.API.PasswordReset
 import Aftok.API.Payments
 import Aftok.API.Projects
@@ -57,6 +59,8 @@ type VersionedAPI =
     :<|> PasswordResetAPI
     -- Client configuration endpoint (public)
     :<|> ConfigAPI
+    -- GitHub webhook endpoint (public, signature-verified)
+    :<|> GitHubWebhookAPI
     -- Protected endpoints (auth required)
     :<|> AftokAuth :> ProtectedAPI
 
@@ -76,6 +80,8 @@ type ProtectedAPI =
     :<|> ProtectedUsersAPI
     -- Session operations (login check)
     :<|> ProtectedSessionAPI
+    -- GitHub username linking (user profile)
+    :<|> "user" :> GitHubUserAPI
 
 -- | Proxy for the API (used for serving and client generation)
 aftokAPI :: Proxy AftokAPI

--- a/api/src/Aftok/API/Auctions.hs
+++ b/api/src/Aftok/API/Auctions.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Auctions API types for the Aftok API.
 module Aftok.API.Auctions
@@ -16,6 +18,7 @@ module Aftok.API.Auctions
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.Auction (AuctionId)
 import Data.Thyme.Format.Aeson ()
 import Data.Aeson
@@ -27,6 +30,9 @@ import Data.Aeson
   )
 import qualified Data.Aeson as A
 import qualified Data.Thyme.Clock as C
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec)
 import Servant.API
 import Aftok.API.Types ()
 
@@ -36,11 +42,17 @@ import Aftok.API.Types ()
 
 -- | Auction creation response
 data AuctionCreateResponse = AuctionCreateResponse
-  { auctionId :: AuctionId
+  { acrAuctionId :: AuctionId
   }
   deriving (Generic)
 
-instance ToJSON AuctionCreateResponse
+instance HasCodec AuctionCreateResponse where
+  codec =
+    object "AuctionCreateResponse" $
+      AuctionCreateResponse
+        <$> requiredField' "auctionId" AC..= acrAuctionId
+
+instance ToJSON AuctionCreateResponse where toJSON = toJSONViaCodec
 
 -- | Auction creation request
 data AuctionCreateRequest = AuctionCreateRequest
@@ -61,6 +73,31 @@ instance FromJSON AuctionCreateRequest where
       <*> auctions .: "auctionStart"
       <*> auctions .: "auctionEnd"
 
+-- | The inner "auctions" object for AuctionCreateRequest codec
+data AuctionInner = AuctionInner
+  { aiName :: Text,
+    aiDescription :: Maybe Text,
+    aiRaiseAmount :: Value,
+    aiStart :: C.UTCTime,
+    aiEnd :: C.UTCTime
+  }
+
+instance HasCodec AuctionInner where
+  codec =
+    object "AuctionInner" $
+      AuctionInner
+        <$> requiredField' "auctionName" AC..= aiName
+        <*> optionalField' "auctionDesc" AC..= aiDescription
+        <*> requiredField' "raiseAmount" AC..= aiRaiseAmount
+        <*> requiredField' "auctionStart" AC..= aiStart
+        <*> requiredField' "auctionEnd" AC..= aiEnd
+
+instance HasCodec AuctionCreateRequest where
+  codec =
+    object "AuctionCreateRequest" $
+      (\inner -> AuctionCreateRequest (aiName inner) (aiDescription inner) (aiRaiseAmount inner) (aiStart inner) (aiEnd inner))
+        <$> requiredField' "auctions" AC..= (\r -> AuctionInner (acrName r) (acrDescription r) (acrRaiseAmount r) (acrAuctionStart r) (acrAuctionEnd r))
+
 -- | Bid creation request
 data BidCreateRequest = BidCreateRequest
   { bcrBidSeconds :: Int,
@@ -73,6 +110,25 @@ instance FromJSON BidCreateRequest where
     BidCreateRequest
       <$> bids .: "bidSeconds"
       <*> bids .: "bidAmount"
+
+-- | The inner "bids" object for BidCreateRequest codec
+data BidInner = BidInner
+  { biSeconds :: Int,
+    biAmount :: Value
+  }
+
+instance HasCodec BidInner where
+  codec =
+    object "BidInner" $
+      BidInner
+        <$> requiredField' "bidSeconds" AC..= biSeconds
+        <*> requiredField' "bidAmount" AC..= biAmount
+
+instance HasCodec BidCreateRequest where
+  codec =
+    object "BidCreateRequest" $
+      (\inner -> BidCreateRequest (biSeconds inner) (biAmount inner))
+        <$> requiredField' "bids" AC..= (\r -> BidInner (bcrBidSeconds r) (bcrBidAmount r))
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/Auth.hs
+++ b/api/src/Aftok/API/Auth.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Authentication types for the Aftok API.
 module Aftok.API.Auth
@@ -13,10 +15,11 @@ module Aftok.API.Auth
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.Types (UserId (..))
-import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
-import qualified Data.Aeson as A
-import qualified Data.UUID as UUID
+import Autodocodec (HasCodec (..), object, requiredField', (.=))
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Servant.Auth (Auth, BasicAuth, Cookie, JWT)
 import Servant.Auth.Server (FromJWT, ToJWT)
 
@@ -27,21 +30,15 @@ data AuthenticatedUser = AuthenticatedUser
   }
   deriving (Eq, Show, Generic)
 
-instance ToJSON AuthenticatedUser where
-  toJSON (AuthenticatedUser (UserId uid) uname) =
-    A.object
-      [ "userId" .= UUID.toText uid,
-        "username" .= uname
-      ]
+instance HasCodec AuthenticatedUser where
+  codec =
+    object "AuthenticatedUser" $
+      AuthenticatedUser
+        <$> requiredField' "userId" .= auUserId
+        <*> requiredField' "username" .= auUsername
 
-instance FromJSON AuthenticatedUser where
-  parseJSON = A.withObject "AuthenticatedUser" $ \o -> do
-    uidText <- o .: "userId"
-    uid <- case UUID.fromText uidText of
-      Nothing -> fail "Invalid UUID for userId"
-      Just u -> pure $ UserId u
-    uname <- o .: "username"
-    pure $ AuthenticatedUser uid uname
+instance ToJSON AuthenticatedUser where toJSON = toJSONViaCodec
+instance FromJSON AuthenticatedUser where parseJSON = parseJSONViaCodec
 
 -- For JWT/cookie auth
 instance ToJWT AuthenticatedUser
@@ -55,10 +52,14 @@ data LoginRequest = LoginRequest
   }
   deriving (Eq, Show, Generic)
 
-instance FromJSON LoginRequest where
-  parseJSON (A.Object o) =
-    LoginRequest <$> o .: "username" <*> o .: "password"
-  parseJSON val = fail $ "Value " <> show val <> " is not a JSON object."
+instance HasCodec LoginRequest where
+  codec =
+    object "LoginRequest" $
+      LoginRequest
+        <$> requiredField' "username" .= loginUser
+        <*> requiredField' "password" .= loginPass
+
+instance FromJSON LoginRequest where parseJSON = parseJSONViaCodec
 
 -- | Auth configuration type for servant-auth
 type AftokAuth = Auth '[BasicAuth, Cookie, JWT] AuthenticatedUser

--- a/api/src/Aftok/API/Billing.hs
+++ b/api/src/Aftok/API/Billing.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Billing API types for the Aftok API.
 module Aftok.API.Billing
@@ -22,23 +24,19 @@ module Aftok.API.Billing
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.Billing (BillableId (..), Recurrence (..), SubscriptionId)
 import Aftok.Payments.Types (PaymentRequestId (..))
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
-    Object,
-    Value (..),
-    (.:),
-    (.:?),
-    (.=),
+    Value,
   )
-import qualified Data.Aeson as A
-import qualified Data.Aeson.KeyMap as O
-import Data.Aeson.Types (Parser)
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Format.Aeson ()
-import qualified Data.UUID as UUID
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
 import Servant.API
 import Aftok.API.Types ()
 
@@ -48,21 +46,33 @@ import Aftok.API.Types ()
 
 -- | Billable creation response
 data BillableCreateResponse = BillableCreateResponse
-  { billableId :: BillableId
+  { bcrBillableId :: BillableId
   }
   deriving (Generic)
 
-instance ToJSON BillableCreateResponse
+instance HasCodec BillableCreateResponse where
+  codec =
+    object "BillableCreateResponse" $
+      BillableCreateResponse
+        <$> requiredField' "billableId" AC..= bcrBillableId
+
+instance ToJSON BillableCreateResponse where toJSON = toJSONViaCodec
 
 -- | Subscription creation response
 data SubscribeResponse = SubscribeResponse
-  { subscriptionId :: SubscriptionId
+  { srSubscriptionId :: SubscriptionId
   }
   deriving (Generic)
 
-instance ToJSON SubscribeResponse
+instance HasCodec SubscribeResponse where
+  codec =
+    object "SubscribeResponse" $
+      SubscribeResponse
+        <$> requiredField' "subscriptionId" AC..= srSubscriptionId
 
--- | Billable creation request
+instance ToJSON SubscribeResponse where toJSON = toJSONViaCodec
+
+-- | Billable creation request (nested format with schemaVersion)
 data BillableCreateRequest = BillableCreateRequest
   { bcrName :: Text,
     bcrDescription :: Text,
@@ -76,22 +86,52 @@ data BillableCreateRequest = BillableCreateRequest
     bcrPaymentRequestMemoTemplate :: Maybe Text
   }
 
-instance FromJSON BillableCreateRequest where
-  parseJSON = A.withObject "BillableCreateRequest" $ \outer -> do
-    v <- outer .: "schemaVersion"
-    when ((v :: Text) /= "1.0") $ fail "Unsupported schema version"
-    o <- outer .: "Billable"
-    BillableCreateRequest
-      <$> o .: "name"
-      <*> o .: "description"
-      <*> o .: "message"
-      <*> (parseRecurrence' =<< o .: "recurrence")
-      <*> o .: "currency"
-      <*> o .: "amount"
-      <*> o .: "gracePeriod"
-      <*> o .: "requestExpiryPeriod"
-      <*> o .:? "paymentRequestEmailTemplate"
-      <*> o .:? "paymentRequestMemoTemplate"
+instance FromJSON BillableCreateRequest where parseJSON = parseJSONViaCodec
+
+-- | Inner billable object for the codec
+data BillableInner = BillableInner
+  { biName :: Text,
+    biDescription :: Text,
+    biMessage :: Text,
+    biRecurrence :: Recurrence,
+    biCurrency :: Text,
+    biAmount :: Int,
+    biGracePeriod :: Int,
+    biRequestExpiryPeriod :: Int,
+    biPaymentRequestEmailTemplate :: Maybe Text,
+    biPaymentRequestMemoTemplate :: Maybe Text
+  }
+
+instance HasCodec BillableInner where
+  codec =
+    object "BillableInner" $
+      BillableInner
+        <$> requiredField' "name" AC..= biName
+        <*> requiredField' "description" AC..= biDescription
+        <*> requiredField' "message" AC..= biMessage
+        <*> requiredField' "recurrence" AC..= biRecurrence
+        <*> requiredField' "currency" AC..= biCurrency
+        <*> requiredField' "amount" AC..= biAmount
+        <*> requiredField' "gracePeriod" AC..= biGracePeriod
+        <*> requiredField' "requestExpiryPeriod" AC..= biRequestExpiryPeriod
+        <*> optionalField' "paymentRequestEmailTemplate" AC..= biPaymentRequestEmailTemplate
+        <*> optionalField' "paymentRequestMemoTemplate" AC..= biPaymentRequestMemoTemplate
+
+instance HasCodec BillableCreateRequest where
+  codec =
+    object "BillableCreateRequest" $
+      (\_ inner ->
+        BillableCreateRequest
+          (biName inner) (biDescription inner) (biMessage inner)
+          (biRecurrence inner) (biCurrency inner) (biAmount inner)
+          (biGracePeriod inner) (biRequestExpiryPeriod inner)
+          (biPaymentRequestEmailTemplate inner) (biPaymentRequestMemoTemplate inner))
+        <$> requiredField' "schemaVersion" AC..= (const ("1.0" :: Text))
+        <*> requiredField' "Billable" AC..= (\r ->
+              BillableInner (bcrName r) (bcrDescription r) (bcrMessage r)
+                (bcrRecurrence r) (bcrCurrency r) (bcrAmount r)
+                (bcrGracePeriod r) (bcrRequestExpiryPeriod r)
+                (bcrPaymentRequestEmailTemplate r) (bcrPaymentRequestMemoTemplate r))
 
 -- | Subscribe request (currently empty, billableId comes from URL)
 data SubscribeRequest = SubscribeRequest
@@ -119,18 +159,20 @@ data BillableResponse = BillableResponse
     brRequestExpiryPeriod :: Int
   }
 
-instance ToJSON BillableResponse where
-  toJSON r =
-    A.object
-      [ "billableId" .= (let BillableId u = brBillableId r in UUID.toText u),
-        "name" .= brName r,
-        "description" .= brDescription r,
-        "message" .= brMessage r,
-        "recurrence" .= recurrenceToJSON (brRecurrence r),
-        "amount" .= brAmount r,
-        "gracePeriod" .= brGracePeriod r,
-        "requestExpiryPeriod" .= brRequestExpiryPeriod r
-      ]
+instance HasCodec BillableResponse where
+  codec =
+    object "BillableResponse" $
+      BillableResponse
+        <$> requiredField' "billableId" AC..= brBillableId
+        <*> requiredField' "name" AC..= brName
+        <*> requiredField' "description" AC..= brDescription
+        <*> requiredField' "message" AC..= brMessage
+        <*> requiredField' "recurrence" AC..= brRecurrence
+        <*> requiredField' "amount" AC..= brAmount
+        <*> requiredField' "gracePeriod" AC..= brGracePeriod
+        <*> requiredField' "requestExpiryPeriod" AC..= brRequestExpiryPeriod
+
+instance ToJSON BillableResponse where toJSON = toJSONViaCodec
 
 -- | Payment request response
 data PaymentRequestResponse = PaymentRequestResponse
@@ -140,14 +182,16 @@ data PaymentRequestResponse = PaymentRequestResponse
     prrNativeRequest :: Value
   }
 
-instance ToJSON PaymentRequestResponse where
-  toJSON r =
-    A.object
-      [ "payment_request_id" .= (let PaymentRequestId u = prrPaymentRequestId r in UUID.toText u),
-        "total" .= prrTotal r,
-        "expires_at" .= prrExpiresAt r,
-        "native_request" .= prrNativeRequest r
-      ]
+instance HasCodec PaymentRequestResponse where
+  codec =
+    object "PaymentRequestResponse" $
+      PaymentRequestResponse
+        <$> requiredField' "payment_request_id" AC..= prrPaymentRequestId
+        <*> requiredField' "total" AC..= prrTotal
+        <*> requiredField' "expires_at" AC..= prrExpiresAt
+        <*> requiredField' "native_request" AC..= prrNativeRequest
+
+instance ToJSON PaymentRequestResponse where toJSON = toJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types
@@ -175,40 +219,3 @@ type ProjectBillablesAPI =
       :> ReqBody '[JSON] PaymentRequestCreateRequest
       :> Post '[JSON] PaymentRequestResponse
 
---------------------------------------------------------------------------------
--- Serialization Helpers
---------------------------------------------------------------------------------
-
--- | Serialize recurrence to JSON (matches handler's existing shape)
-recurrenceToJSON :: Recurrence -> Value
-recurrenceToJSON = \case
-  Annually -> A.object ["annually" .= A.Null]
-  Monthly d -> A.object ["monthly" .= d]
-  Weekly d -> A.object ["weekly" .= d]
-  OneTime -> A.object ["onetime" .= A.Null]
-
---------------------------------------------------------------------------------
--- Parsing Helpers
---------------------------------------------------------------------------------
-
--- | Parse a recurrence value from JSON
-parseRecurrence :: Object -> Parser Recurrence
-parseRecurrence o =
-  let parseAnnually o' = const (pure Annually) <$> O.lookup "annually" o'
-      parseMonthly o' = fmap Monthly . A.parseJSON <$> O.lookup "monthly" o'
-      parseWeekly o' = fmap Weekly . A.parseJSON <$> O.lookup "weekly" o'
-      parseOneTime o' = const (pure OneTime) <$> O.lookup "onetime" o'
-      notFound =
-        fail $ "Value " <> show o <> " does not represent a Recurrence value."
-      parseV val =
-        parseAnnually val
-          <|> parseMonthly val
-          <|> parseWeekly val
-          <|> parseOneTime val
-   in fromMaybe notFound $ parseV o
-
--- | Parse a recurrence from a JSON value
-parseRecurrence' :: Value -> Parser Recurrence
-parseRecurrence' = \case
-  (Object o) -> parseRecurrence o
-  val -> fail $ "Value " <> show val <> " is not a JSON object."

--- a/api/src/Aftok/API/Codec.hs
+++ b/api/src/Aftok/API/Codec.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Autodocodec 'HasCodec' instances for core library types that appear
+-- in API request/response types. These codecs define the API wire format
+-- only — the database layer has its own serialization and is unaffected.
+module Aftok.API.Codec () where
+
+import Autodocodec
+  ( HasCodec (..),
+    JSONCodec,
+    dimapCodec,
+    bimapCodec,
+    object,
+    optionalField,
+    requiredField',
+    disjointEitherCodec,
+    (.=),
+    (<?>),
+  )
+import Aftok.Auction (AuctionId (..))
+import Aftok.Billing (BillableId (..), Recurrence (..), SubscriptionId (..))
+import Aftok.Payments.Types (PaymentId (..), PaymentRequestId (..))
+import Aftok.TimeLog (AmendmentId (..), EventId (..), LogEvent (..))
+import Aftok.Types
+  ( AccountId (..),
+    CreditTo (..),
+    DepreciationFunction (..),
+    ProjectId (..),
+    UserId (..),
+    UserName (..),
+  )
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (fromThyme, toThyme)
+import qualified Data.Time as Time
+import qualified Data.UUID as UUID
+
+--------------------------------------------------------------------------------
+-- UUID wrapper types
+--------------------------------------------------------------------------------
+
+uuidCodec :: (a -> UUID.UUID) -> (UUID.UUID -> a) -> Text -> JSONCodec a
+uuidCodec unwrap wrap name =
+  bimapCodec
+    (maybe (Left "Invalid UUID") Right . fmap wrap . UUID.fromText)
+    (UUID.toText . unwrap)
+    (codec @Text <?> name)
+
+instance HasCodec UserId where
+  codec = uuidCodec (\(UserId u) -> u) UserId "UserId UUID"
+
+instance HasCodec ProjectId where
+  codec = uuidCodec (\(ProjectId u) -> u) ProjectId "ProjectId UUID"
+
+instance HasCodec AccountId where
+  codec = uuidCodec (\(AccountId u) -> u) AccountId "AccountId UUID"
+
+instance HasCodec EventId where
+  codec = uuidCodec (\(EventId u) -> u) EventId "EventId UUID"
+
+instance HasCodec AmendmentId where
+  codec = uuidCodec (\(AmendmentId u) -> u) AmendmentId "AmendmentId UUID"
+
+instance HasCodec BillableId where
+  codec = uuidCodec (\(BillableId u) -> u) BillableId "BillableId UUID"
+
+instance HasCodec AuctionId where
+  codec = uuidCodec (\(AuctionId u) -> u) AuctionId "AuctionId UUID"
+
+instance HasCodec SubscriptionId where
+  codec = uuidCodec (\(SubscriptionId u) -> u) SubscriptionId "SubscriptionId UUID"
+
+instance HasCodec PaymentRequestId where
+  codec = uuidCodec (\(PaymentRequestId u) -> u) PaymentRequestId "PaymentRequestId UUID"
+
+instance HasCodec PaymentId where
+  codec = uuidCodec (\(PaymentId u) -> u) PaymentId "PaymentId UUID"
+
+--------------------------------------------------------------------------------
+-- Thyme UTCTime
+--------------------------------------------------------------------------------
+
+instance HasCodec C.UTCTime where
+  codec = dimapCodec toThyme fromThyme (codec @Time.UTCTime)
+
+--------------------------------------------------------------------------------
+-- Simple newtypes
+--------------------------------------------------------------------------------
+
+instance HasCodec UserName where
+  codec = dimapCodec UserName (\(UserName t) -> t) codec
+
+--------------------------------------------------------------------------------
+-- CreditTo
+--
+-- Matches existing creditToJSON/parseCreditToV2 format:
+--   {"creditToAccount": "<uuid>"}
+-- | {"creditToUser": "<uuid>"}
+-- | {"creditToProject": "<uuid>"}
+--------------------------------------------------------------------------------
+
+instance HasCodec CreditTo where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec accountCodec $
+        disjointEitherCodec userCodec projectCodec
+    where
+      accountCodec =
+        object "CreditToAccount" $
+          requiredField' "creditToAccount" .= id
+      userCodec =
+        object "CreditToUser" $
+          requiredField' "creditToUser" .= id
+      projectCodec =
+        object "CreditToProject" $
+          requiredField' "creditToProject" .= id
+      fromEither :: Either AccountId (Either UserId ProjectId) -> CreditTo
+      fromEither = \case
+        Left a -> CreditToAccount a
+        Right (Left u) -> CreditToUser u
+        Right (Right p) -> CreditToProject p
+      toEither :: CreditTo -> Either AccountId (Either UserId ProjectId)
+      toEither = \case
+        CreditToAccount a -> Left a
+        CreditToUser u -> Right (Left u)
+        CreditToProject p -> Right (Right p)
+
+--------------------------------------------------------------------------------
+-- DepreciationFunction
+--
+-- Matches existing depfToJSON/depfFromJSON format:
+--   {"type": "LinearDepreciation", "arguments": {"undep": N, "dep": N}}
+--------------------------------------------------------------------------------
+
+-- Helper type for the nested "arguments" object
+data LinearDepArgs = LinearDepArgs Int Int
+
+instance HasCodec LinearDepArgs where
+  codec =
+    object "LinearDepreciationArgs" $
+      LinearDepArgs
+        <$> requiredField' "undep" .= (\(LinearDepArgs u _) -> u)
+        <*> requiredField' "dep" .= (\(LinearDepArgs _ d) -> d)
+
+instance HasCodec DepreciationFunction where
+  codec =
+    object "DepreciationFunction" $
+      (\_ args -> case args of LinearDepArgs u d -> LinearDepreciation u d)
+        <$> requiredField' "type" .= (\(LinearDepreciation _ _) -> ("LinearDepreciation" :: Text))
+        <*> requiredField' "arguments" .= (\(LinearDepreciation u d) -> LinearDepArgs u d)
+
+--------------------------------------------------------------------------------
+-- LogEvent
+--
+-- Matches existing logEventToJSON format:
+--   {"start": {"eventTime": "<iso8601>"}}
+-- | {"stop": {"eventTime": "<iso8601>"}}
+--------------------------------------------------------------------------------
+
+newtype EventTimeWrapper = EventTimeWrapper C.UTCTime
+
+instance HasCodec EventTimeWrapper where
+  codec =
+    object "EventTime" $
+      EventTimeWrapper <$> requiredField' "eventTime" .= (\(EventTimeWrapper t) -> t)
+
+instance HasCodec LogEvent where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec startCodec stopCodec
+    where
+      startCodec =
+        object "StartWork" $
+          requiredField' "start" .= id
+      stopCodec =
+        object "StopWork" $
+          requiredField' "stop" .= id
+      fromEither :: Either EventTimeWrapper EventTimeWrapper -> LogEvent
+      fromEither = \case
+        Left (EventTimeWrapper t) -> StartWork t
+        Right (EventTimeWrapper t) -> StopWork t
+      toEither :: LogEvent -> Either EventTimeWrapper EventTimeWrapper
+      toEither = \case
+        StartWork t -> Left (EventTimeWrapper t)
+        StopWork t -> Right (EventTimeWrapper t)
+
+--------------------------------------------------------------------------------
+-- Recurrence
+--
+-- Matches existing recurrenceToJSON/parseRecurrence format:
+--   {"annually": null} | {"monthly": N} | {"weekly": N} | {"onetime": null}
+--------------------------------------------------------------------------------
+
+instance HasCodec Recurrence where
+  codec =
+    dimapCodec fromEither toEither $
+      disjointEitherCodec annuallyCodec $
+        disjointEitherCodec monthlyCodec $
+          disjointEitherCodec weeklyCodec onetimeCodec
+    where
+      annuallyCodec =
+        object "Annually" $
+          optionalField "annually" "null marker" .= id
+      monthlyCodec =
+        object "Monthly" $
+          requiredField' "monthly" .= id
+      weeklyCodec =
+        object "Weekly" $
+          requiredField' "weekly" .= id
+      onetimeCodec =
+        object "OneTime" $
+          optionalField "onetime" "null marker" .= id
+      fromEither :: Either (Maybe Int) (Either Int (Either Int (Maybe Int))) -> Recurrence
+      fromEither = \case
+        Left _ -> Annually
+        Right (Left n) -> Monthly n
+        Right (Right (Left n)) -> Weekly n
+        Right (Right (Right _)) -> OneTime
+      toEither :: Recurrence -> Either (Maybe Int) (Either Int (Either Int (Maybe Int)))
+      toEither = \case
+        Annually -> Left Nothing
+        Monthly n -> Right (Left n)
+        Weekly n -> Right (Right (Left n))
+        OneTime -> Right (Right (Right Nothing))

--- a/api/src/Aftok/API/Codec.hs
+++ b/api/src/Aftok/API/Codec.hs
@@ -27,6 +27,9 @@ import Aftok.Types
   ( AccountId (..),
     CreditTo (..),
     DepreciationFunction (..),
+    GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    GitHubWebhookEventId (..),
     ProjectId (..),
     UserId (..),
     UserName (..),
@@ -77,6 +80,12 @@ instance HasCodec PaymentRequestId where
 instance HasCodec PaymentId where
   codec = uuidCodec (\(PaymentId u) -> u) PaymentId "PaymentId UUID"
 
+instance HasCodec GitHubRepoLinkId where
+  codec = uuidCodec (\(GitHubRepoLinkId u) -> u) GitHubRepoLinkId "GitHubRepoLinkId UUID"
+
+instance HasCodec GitHubWebhookEventId where
+  codec = uuidCodec (\(GitHubWebhookEventId u) -> u) GitHubWebhookEventId "GitHubWebhookEventId UUID"
+
 --------------------------------------------------------------------------------
 -- Thyme UTCTime
 --------------------------------------------------------------------------------
@@ -90,6 +99,9 @@ instance HasCodec C.UTCTime where
 
 instance HasCodec UserName where
   codec = dimapCodec UserName (\(UserName t) -> t) codec
+
+instance HasCodec GitHubUsername where
+  codec = dimapCodec GitHubUsername (\(GitHubUsername t) -> t) codec
 
 --------------------------------------------------------------------------------
 -- CreditTo

--- a/api/src/Aftok/API/Config.hs
+++ b/api/src/Aftok/API/Config.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Config API types for the Aftok API.
 module Aftok.API.Config
@@ -12,7 +14,10 @@ module Aftok.API.Config
   )
 where
 
-import Data.Aeson (ToJSON)
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, requiredField')
+import Autodocodec.Aeson (toJSONViaCodec)
+import Data.Aeson (ToJSON (..))
 import Servant.API
 
 -- | Client configuration returned by the server
@@ -21,7 +26,13 @@ data ClientConfig = ClientConfig
   }
   deriving (Show, Generic)
 
-instance ToJSON ClientConfig
+instance HasCodec ClientConfig where
+  codec =
+    object "ClientConfig" $
+      ClientConfig
+        <$> requiredField' "recaptchaSiteKey" AC..= recaptchaSiteKey
+
+instance ToJSON ClientConfig where toJSON = toJSONViaCodec
 
 -- | Configuration API - public endpoint for client config
 type ConfigAPI =

--- a/api/src/Aftok/API/GitHub.hs
+++ b/api/src/Aftok/API/GitHub.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | GitHub integration API types for the Aftok API.
+module Aftok.API.GitHub
+  ( -- * API Types
+    GitHubWebhookAPI,
+    GitHubProjectAPI,
+    GitHubUserAPI,
+
+    -- * Request/Response Types
+    LinkRepoRequest (..),
+    LinkRepoResponse (..),
+    RepoLinkInfo (..),
+    LinkGitHubUsernameRequest (..),
+    GitHubUsernameResponse (..),
+  )
+where
+
+import Aftok.API.Codec ()
+import Aftok.Types (GitHubRepoLinkId (..))
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (parseJSONViaCodec, toJSONViaCodec)
+import Data.Aeson
+  ( FromJSON (..),
+    ToJSON (..),
+    Value (..),
+  )
+import qualified Data.Thyme.Clock as C
+import Data.UUID (UUID)
+import Servant.API
+
+--------------------------------------------------------------------------------
+-- Request/Response Types
+--------------------------------------------------------------------------------
+
+-- | Request to link a GitHub repository to a project
+data LinkRepoRequest = LinkRepoRequest
+  { lrrOwner :: Text,
+    lrrRepo :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec LinkRepoRequest where
+  codec =
+    object "LinkRepoRequest" $
+      LinkRepoRequest
+        <$> requiredField' "owner" AC..= lrrOwner
+        <*> requiredField' "repo" AC..= lrrRepo
+
+instance FromJSON LinkRepoRequest where parseJSON = parseJSONViaCodec
+
+-- | Response when linking a repository
+data LinkRepoResponse = LinkRepoResponse
+  { lrLinkId :: GitHubRepoLinkId,
+    lrWebhookSecret :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec LinkRepoResponse where
+  codec =
+    object "LinkRepoResponse" $
+      LinkRepoResponse
+        <$> requiredField' "linkId" AC..= lrLinkId
+        <*> requiredField' "webhookSecret" AC..= lrWebhookSecret
+
+instance ToJSON LinkRepoResponse where toJSON = toJSONViaCodec
+
+-- | Information about a linked repository
+data RepoLinkInfo = RepoLinkInfo
+  { rliId :: GitHubRepoLinkId,
+    rliOwner :: Text,
+    rliRepo :: Text,
+    rliCreatedAt :: C.UTCTime
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec RepoLinkInfo where
+  codec =
+    object "RepoLinkInfo" $
+      RepoLinkInfo
+        <$> requiredField' "id" AC..= rliId
+        <*> requiredField' "owner" AC..= rliOwner
+        <*> requiredField' "repo" AC..= rliRepo
+        <*> requiredField' "createdAt" AC..= rliCreatedAt
+
+instance ToJSON RepoLinkInfo where toJSON = toJSONViaCodec
+
+-- | Request to link a GitHub username to user account
+data LinkGitHubUsernameRequest = LinkGitHubUsernameRequest
+  { lgurUsername :: Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec LinkGitHubUsernameRequest where
+  codec =
+    object "LinkGitHubUsernameRequest" $
+      LinkGitHubUsernameRequest
+        <$> requiredField' "username" AC..= lgurUsername
+
+instance FromJSON LinkGitHubUsernameRequest where parseJSON = parseJSONViaCodec
+
+-- | Response with GitHub username info
+data GitHubUsernameResponse = GitHubUsernameResponse
+  { ghurUsername :: Maybe Text
+  }
+  deriving (Show, Eq, Generic)
+
+instance HasCodec GitHubUsernameResponse where
+  codec =
+    object "GitHubUsernameResponse" $
+      GitHubUsernameResponse
+        <$> optionalField' "username" AC..= ghurUsername
+
+instance ToJSON GitHubUsernameResponse where toJSON = toJSONViaCodec
+
+--------------------------------------------------------------------------------
+-- API Types
+--------------------------------------------------------------------------------
+
+-- | Public GitHub webhook endpoint (no auth, uses signature verification)
+type GitHubWebhookAPI =
+  "webhooks"
+    :> "github"
+    :> Header "X-GitHub-Event" Text
+    :> Header "X-GitHub-Delivery" Text
+    :> Header "X-Hub-Signature-256" Text
+    :> ReqBody '[JSON] Value
+    :> Post '[JSON] NoContent
+
+-- | Project-level GitHub management API (protected)
+type GitHubProjectAPI =
+  "github"
+    :> "repos"
+    :> ( -- GET /projects/:projectId/github/repos - List linked repos
+         Get '[JSON] [RepoLinkInfo]
+           -- POST /projects/:projectId/github/repos - Link a repo
+           :<|> ReqBody '[JSON] LinkRepoRequest :> Post '[JSON] LinkRepoResponse
+           -- DELETE /projects/:projectId/github/repos/:id - Unlink a repo
+           :<|> Capture "linkId" UUID :> Delete '[JSON] NoContent
+       )
+
+-- | User-level GitHub username linking API (protected)
+type GitHubUserAPI =
+  "github"
+    :> ( -- GET /user/github - Get linked GitHub username
+         Get '[JSON] GitHubUsernameResponse
+           -- PUT /user/github - Link GitHub username
+           :<|> ReqBody '[JSON] LinkGitHubUsernameRequest :> Put '[JSON] NoContent
+           -- DELETE /user/github - Unlink GitHub username
+           :<|> Delete '[JSON] NoContent
+       )

--- a/api/src/Aftok/API/OpenApi.hs
+++ b/api/src/Aftok/API/OpenApi.hs
@@ -19,6 +19,13 @@ import Aftok.API.Billing
     SubscribeResponse,
   )
 import Aftok.API.Config (ClientConfig)
+import Aftok.API.GitHub
+  ( GitHubUsernameResponse,
+    LinkGitHubUsernameRequest,
+    LinkRepoRequest,
+    LinkRepoResponse,
+    RepoLinkInfo,
+  )
 import Aftok.API.PasswordReset
   ( PasswordResetConfirm,
     PasswordResetRequest,
@@ -64,7 +71,7 @@ import Aftok.API.Payments (BIP70Data (..))
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
-import Aftok.Types (ProjectId (..), UserId (..))
+import Aftok.Types (GitHubRepoLinkId (..), ProjectId (..), UserId (..))
 import Autodocodec.OpenAPI (declareNamedSchemaViaCodec)
 
 import Control.Lens ((.~), (?~))
@@ -295,4 +302,23 @@ instance ToSchema PasswordResetConfirm where
 
 -- Config
 instance ToSchema ClientConfig where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+-- GitHub
+instance ToSchema GitHubRepoLinkId where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema LinkRepoRequest where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema LinkRepoResponse where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema RepoLinkInfo where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema LinkGitHubUsernameRequest where
+  declareNamedSchema = declareNamedSchemaViaCodec
+
+instance ToSchema GitHubUsernameResponse where
   declareNamedSchema = declareNamedSchemaViaCodec

--- a/api/src/Aftok/API/OpenApi.hs
+++ b/api/src/Aftok/API/OpenApi.hs
@@ -59,11 +59,13 @@ import Aftok.API.Auctions
     AuctionCreateResponse,
     BidCreateRequest,
   )
+import Aftok.API.Codec ()
 import Aftok.API.Payments (BIP70Data (..))
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
 import Aftok.Types (ProjectId (..), UserId (..))
+import Autodocodec.OpenAPI (declareNamedSchemaViaCodec)
 
 import Control.Lens ((.~), (?~))
 import Data.OpenApi
@@ -118,26 +120,26 @@ instance ToParamSchema C.UTCTime where
     & OA.format ?~ "date-time"
 
 --------------------------------------------------------------------------------
--- ToSchema instances for core types
+-- ToSchema instances for core types (codec-derived)
 --------------------------------------------------------------------------------
 
 instance ToSchema ProjectId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "ProjectId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema UserId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "UserId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "BillableId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AuctionId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "AuctionId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SubscriptionId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "SubscriptionId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PaymentId where
-  declareNamedSchema _ = pure $ NamedSchema (Just "PaymentId") uuidParamSchema
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- | thyme UTCTime → delegate to time's UTCTime schema
 instance ToSchema C.UTCTime where
@@ -146,16 +148,8 @@ instance ToSchema C.UTCTime where
     pure $ s { _namedSchemaName = Just "UTCTime" }
 
 --------------------------------------------------------------------------------
--- ToSchema instances for API request/response types
---
--- Types with custom ToJSON instances use a simple freeform object schema.
--- This is pragmatic: the ToJSON instances hand-write field names that don't
--- match Haskell record fields, so Generic-based derivation would be wrong.
+-- ToSchema instances for special types
 --------------------------------------------------------------------------------
-
-freeformObject :: Text -> OA.NamedSchema
-freeformObject name = NamedSchema (Just name)
-  (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 -- | Aeson Value as freeform JSON — used by untyped response endpoints
 instance ToSchema A.Value where
@@ -165,131 +159,140 @@ instance ToSchema A.Value where
 instance ToSchema BIP70Data where
   declareNamedSchema _ = pure $ NamedSchema (Just "BIP70Data") OA.binarySchema
 
+--------------------------------------------------------------------------------
+-- ToSchema instances for API request/response types (codec-derived)
+--------------------------------------------------------------------------------
+
 -- Auth
 instance ToSchema AuthenticatedUser where
-  declareNamedSchema _ = pure $ freeformObject "AuthenticatedUser"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema LoginRequest where
-  declareNamedSchema _ = pure $ freeformObject "LoginRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Users
 instance ToSchema RegisterRequest where
-  declareNamedSchema _ = pure $ freeformObject "RegisterRequest"
+  declareNamedSchema _ = pure $ NamedSchema (Just "RegisterRequest")
+    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema RegisterResponse where
-  declareNamedSchema _ = pure $ freeformObject "RegisterResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema UsernameCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "UsernameCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ZAddrCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "ZAddrCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AccountSettingsResponse where
-  declareNamedSchema _ = pure $ freeformObject "AccountSettingsResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SetPaymentAddressRequest where
-  declareNamedSchema _ = pure $ freeformObject "SetPaymentAddressRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Session
 instance ToSchema LoginCheckResponse where
-  declareNamedSchema _ = pure $ freeformObject "LoginCheckResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Projects
 instance ToSchema ProjectCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "ProjectCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectSummary where
-  declareNamedSchema _ = pure $ freeformObject "ProjectSummary"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectDetailResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectDetailResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectInviteRequest where
-  declareNamedSchema _ = pure $ freeformObject "ProjectInviteRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema ProjectInviteResponse where
-  declareNamedSchema _ = pure $ freeformObject "ProjectInviteResponse"
+  declareNamedSchema _ = pure $ NamedSchema (Just "ProjectInviteResponse")
+    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema CommsAddress where
-  declareNamedSchema _ = pure $ freeformObject "CommsAddress"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- WorkLog
 instance ToSchema LogStartRequest where
-  declareNamedSchema _ = pure $ freeformObject "LogStartRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema LogEndRequest where
-  declareNamedSchema _ = pure $ freeformObject "LogEndRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema EventAmendmentRequest where
-  declareNamedSchema _ = pure $ freeformObject "EventAmendmentRequest"
+  declareNamedSchema _ = pure $ NamedSchema (Just "EventAmendmentRequest")
+    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema ExtendedLogEntryResponse where
-  declareNamedSchema _ = pure $ freeformObject "ExtendedLogEntryResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema KeyedLogEntryResponse where
-  declareNamedSchema _ = pure $ freeformObject "KeyedLogEntryResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema WorkIndexResponse where
-  declareNamedSchema _ = pure $ freeformObject "WorkIndexResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema WorkIndexEntry where
-  declareNamedSchema _ = pure $ freeformObject "WorkIndexEntry"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema IntervalResponse where
-  declareNamedSchema _ = pure $ freeformObject "IntervalResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AmendEventResponse where
-  declareNamedSchema _ = pure $ freeformObject "AmendEventResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Auctions
 instance ToSchema AuctionCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "AuctionCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema AuctionCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "AuctionCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BidCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "BidCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Billing
 instance ToSchema BillableCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "BillableCreateRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableCreateResponse where
-  declareNamedSchema _ = pure $ freeformObject "BillableCreateResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema BillableResponse where
-  declareNamedSchema _ = pure $ freeformObject "BillableResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PaymentRequestCreateRequest where
-  declareNamedSchema _ = pure $ freeformObject "PaymentRequestCreateRequest"
+  declareNamedSchema _ = pure $ NamedSchema (Just "PaymentRequestCreateRequest")
+    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema PaymentRequestResponse where
-  declareNamedSchema _ = pure $ freeformObject "PaymentRequestResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema SubscribeRequest where
-  declareNamedSchema _ = pure $ freeformObject "SubscribeRequest"
+  declareNamedSchema _ = pure $ NamedSchema (Just "SubscribeRequest")
+    (mempty & OA.type_ ?~ OA.OpenApiObject)
 
 instance ToSchema SubscribeResponse where
-  declareNamedSchema _ = pure $ freeformObject "SubscribeResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Password Reset
 instance ToSchema PasswordResetRequest where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetRequest"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PasswordResetResponse where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetResponse"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 instance ToSchema PasswordResetConfirm where
-  declareNamedSchema _ = pure $ freeformObject "PasswordResetConfirm"
+  declareNamedSchema = declareNamedSchemaViaCodec
 
 -- Config
 instance ToSchema ClientConfig where
-  declareNamedSchema _ = pure $ freeformObject "ClientConfig"
+  declareNamedSchema = declareNamedSchemaViaCodec

--- a/api/src/Aftok/API/PasswordReset.hs
+++ b/api/src/Aftok/API/PasswordReset.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Password Reset API types for the Aftok API.
 module Aftok.API.PasswordReset
@@ -14,8 +16,10 @@ module Aftok.API.PasswordReset
   )
 where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
-import qualified Data.Aeson as A
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Servant.API
 
 -- | Password reset API
@@ -43,13 +47,14 @@ data PasswordResetRequest = PasswordResetRequest
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON PasswordResetRequest where
-  parseJSON = A.withObject "PasswordResetRequest" $ \o ->
-    PasswordResetRequest
-      <$> o .:? "username"
-      <*> o .:? "email"
-    where
-      (.:?) obj key = obj .: key <|> pure Nothing
+instance HasCodec PasswordResetRequest where
+  codec =
+    object "PasswordResetRequest" $
+      PasswordResetRequest
+        <$> optionalField' "username" AC..= prrUsername
+        <*> optionalField' "email" AC..= prrEmail
+
+instance FromJSON PasswordResetRequest where parseJSON = parseJSONViaCodec
 
 -- | Response for password reset request (always success for security)
 data PasswordResetResponse = PasswordResetResponse
@@ -57,9 +62,13 @@ data PasswordResetResponse = PasswordResetResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON PasswordResetResponse where
-  toJSON (PasswordResetResponse msg) =
-    A.object ["message" .= msg]
+instance HasCodec PasswordResetResponse where
+  codec =
+    object "PasswordResetResponse" $
+      PasswordResetResponse
+        <$> requiredField' "message" AC..= prsMessage
+
+instance ToJSON PasswordResetResponse where toJSON = toJSONViaCodec
 
 -- | Confirm password reset with token
 data PasswordResetConfirm = PasswordResetConfirm
@@ -68,8 +77,11 @@ data PasswordResetConfirm = PasswordResetConfirm
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON PasswordResetConfirm where
-  parseJSON = A.withObject "PasswordResetConfirm" $ \o ->
-    PasswordResetConfirm
-      <$> o .: "token"
-      <*> o .: "newPassword"
+instance HasCodec PasswordResetConfirm where
+  codec =
+    object "PasswordResetConfirm" $
+      PasswordResetConfirm
+        <$> requiredField' "token" AC..= prcToken
+        <*> requiredField' "newPassword" AC..= prcNewPassword
+
+instance FromJSON PasswordResetConfirm where parseJSON = parseJSONViaCodec

--- a/api/src/Aftok/API/Projects.hs
+++ b/api/src/Aftok/API/Projects.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Projects API types for the Aftok API.
 module Aftok.API.Projects
@@ -36,10 +39,10 @@ where
 
 import Aftok.API.Auctions (ProjectAuctionsAPI)
 import Aftok.API.Billing (ProjectBillablesAPI)
+import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import qualified Aftok.Currency.Zcash.Zip321 as Zip321
 import Aftok.Project (Project (..))
-import Aftok.TimeLog.Serialization (depfFromJSON)
 import Aftok.Types
   ( DepreciationFunction (..),
     DepreciationRules (..),
@@ -47,20 +50,22 @@ import Aftok.Types
     UserId (..),
     UserName (..),
   )
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
 import Control.Lens (makeLenses)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     Value (..),
-    object,
-    (.:),
-    (.:?),
     (.=),
   )
 import qualified Data.Aeson as A
 import qualified Data.Map.Strict as M
+import Data.Ratio ((%))
+
 import qualified Data.Thyme.Clock as C
-import qualified Data.UUID as UUID
+
 import Servant.API
 import Time.Types (Hours (..))
 
@@ -74,10 +79,14 @@ data ProjectCreateRequest = ProjectCreateRequest
     cpdepf :: DepreciationFunction
   }
 
-instance FromJSON ProjectCreateRequest where
-  parseJSON (A.Object v) =
-    ProjectCreateRequest <$> v .: "projectName" <*> (depfFromJSON =<< v .: "depf")
-  parseJSON _ = mzero
+instance FromJSON ProjectCreateRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec ProjectCreateRequest where
+  codec =
+    object "ProjectCreateRequest" $
+      ProjectCreateRequest
+        <$> requiredField' "projectName" AC..= cpn
+        <*> requiredField' "depf" AC..= cpdepf
 
 -- | Contributor record for project detail
 data Contributor = Contributor
@@ -104,6 +113,22 @@ data CommsAddress
   = EmailComms Text
   | ZcashComms Text
 
+instance HasCodec CommsAddress where
+  codec =
+    AC.dimapCodec fromEither toEither $
+      AC.disjointEitherCodec emailCodec zAddrCodec
+    where
+      emailCodec = object "EmailComms" $ requiredField' "email" AC..= id
+      zAddrCodec = object "ZcashComms" $ requiredField' "zaddr" AC..= id
+      fromEither :: Either Text Text -> CommsAddress
+      fromEither = \case
+        Left e -> EmailComms e
+        Right z -> ZcashComms z
+      toEither :: CommsAddress -> Either Text Text
+      toEither = \case
+        EmailComms e -> Left e
+        ZcashComms z -> Right z
+
 -- | Project invitation request
 data ProjectInviteRequest = ProjectInviteRequest
   { greetName :: Text,
@@ -111,17 +136,15 @@ data ProjectInviteRequest = ProjectInviteRequest
     inviteBy :: CommsAddress
   }
 
-instance FromJSON ProjectInviteRequest where
-  parseJSON (A.Object v) = do
-    name <- v .: "greetName"
-    msg <- v .:? "message"
-    comms <- v .: "inviteBy"
-    emailComms <- fmap EmailComms <$> (comms .:? "email")
-    zcashComms <- fmap ZcashComms <$> (comms .:? "zaddr")
-    case emailComms <|> zcashComms of
-      Nothing -> mzero
-      Just addr -> pure $ ProjectInviteRequest name msg addr
-  parseJSON _ = mzero
+instance FromJSON ProjectInviteRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec ProjectInviteRequest where
+  codec =
+    object "ProjectInviteRequest" $
+      ProjectInviteRequest
+        <$> requiredField' "greetName" AC..= greetName
+        <*> optionalField' "message" AC..= pirMessage
+        <*> requiredField' "inviteBy" AC..= inviteBy
 
 -- | Project invitation response
 data ProjectInviteResponse = ProjectInviteResponse
@@ -130,9 +153,9 @@ data ProjectInviteResponse = ProjectInviteResponse
   deriving (Generic)
 
 instance ToJSON ProjectInviteResponse where
-  toJSON (ProjectInviteResponse Nothing) = object []
+  toJSON (ProjectInviteResponse Nothing) = A.object []
   toJSON (ProjectInviteResponse (Just r)) =
-    object ["zip321_request" .= (A.toJSON . Zip321.toURI $ r)]
+    A.object ["zip321_request" .= (A.toJSON . Zip321.toURI $ r)]
 
 --------------------------------------------------------------------------------
 -- Response Types (defined after TH splices)
@@ -140,19 +163,65 @@ instance ToJSON ProjectInviteResponse where
 
 -- | Project creation response
 data ProjectCreateResponse = ProjectCreateResponse
-  { projectId :: ProjectId
+  { pcrProjectId :: ProjectId
   }
   deriving (Generic)
 
-instance ToJSON ProjectCreateResponse
+instance HasCodec ProjectCreateResponse where
+  codec =
+    object "ProjectCreateResponse" $
+      ProjectCreateResponse
+        <$> requiredField' "projectId" AC..= pcrProjectId
+
+instance ToJSON ProjectCreateResponse where toJSON = toJSONViaCodec
+
+-- | Helper codec for serializing a Project to a flat JSON object
+projectCodec :: AC.JSONObjectCodec ProjectFields
+projectCodec =
+  ProjectFields
+    <$> requiredField' "projectName" AC..= pfName
+    <*> requiredField' "inceptionDate" AC..= pfInceptionDate
+    <*> requiredField' "initiator" AC..= pfInitiator
+    <*> requiredField' "depf" AC..= pfDepf
+
+data ProjectFields = ProjectFields
+  { pfName :: Text,
+    pfInceptionDate :: C.UTCTime,
+    pfInitiator :: UserId,
+    pfDepf :: DepreciationFunction
+  }
+
+instance HasCodec ProjectFields where
+  codec = object "Project" projectCodec
+
+projectToFields :: Project -> ProjectFields
+projectToFields p =
+  ProjectFields
+    { pfName = _projectName p,
+      pfInceptionDate = _inceptionDate p,
+      pfInitiator = _initiator p,
+      pfDepf = _depf (_depRules p)
+    }
 
 -- | Project response for GET /projects/:pid (flat project fields)
 data ProjectResponse = ProjectResponse
   { prProject :: Project
   }
 
-instance ToJSON ProjectResponse where
-  toJSON (ProjectResponse p) = projectToJSON p
+instance HasCodec ProjectResponse where
+  codec =
+    AC.dimapCodec (ProjectResponse . fieldsToProject) (projectToFields . prProject) $
+      codec @ProjectFields
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+
+instance ToJSON ProjectResponse where toJSON = toJSONViaCodec
 
 -- | Project summary for GET /projects list (with projectId)
 data ProjectSummary = ProjectSummary
@@ -160,63 +229,100 @@ data ProjectSummary = ProjectSummary
     psProject :: Project
   }
 
-instance ToJSON ProjectSummary where
-  toJSON (ProjectSummary pid p) =
-    object
-      [ "projectId" .= pid,
-        "project" .= projectToJSON p
-      ]
+instance HasCodec ProjectSummary where
+  codec =
+    object "ProjectSummary" $
+      (\pid pf -> ProjectSummary pid (fieldsToProject pf))
+        <$> requiredField' "projectId" AC..= psProjectId
+        <*> requiredField' "project" AC..= (projectToFields . psProject)
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+
+instance ToJSON ProjectSummary where toJSON = toJSONViaCodec
+
+-- | Contributor serialization helper
+data ContributorFields = ContributorFields
+  { cfUserId :: UserId,
+    cfUsername :: Text,
+    cfJoinedOn :: C.UTCTime,
+    cfLoggedHours :: Int64,
+    cfDepreciatedHours :: Int64,
+    cfRevenueShare :: RationalFields
+  }
+
+data RationalFields = RationalFields
+  { rfNumerator :: Integer,
+    rfDenominator :: Integer
+  }
+
+instance HasCodec RationalFields where
+  codec =
+    object "RationalFields" $
+      RationalFields
+        <$> requiredField' "numerator" AC..= rfNumerator
+        <*> requiredField' "denominator" AC..= rfDenominator
+
+instance HasCodec ContributorFields where
+  codec =
+    object "Contributor" $
+      ContributorFields
+        <$> requiredField' "userId" AC..= cfUserId
+        <*> requiredField' "username" AC..= cfUsername
+        <*> requiredField' "joinedOn" AC..= cfJoinedOn
+        <*> requiredField' "loggedHours" AC..= cfLoggedHours
+        <*> requiredField' "depreciatedHours" AC..= cfDepreciatedHours
+        <*> requiredField' "revenueShare" AC..= cfRevenueShare
+
+contributorToFields :: Contributor -> ContributorFields
+contributorToFields c =
+  ContributorFields
+    { cfUserId = _cUserId c,
+      cfUsername = let UserName n = _cHandle c in n,
+      cfJoinedOn = _cJoinedOn c,
+      cfLoggedHours = let Hours h = _cLoggedHours c in h,
+      cfDepreciatedHours = let Hours h = _cDepreciatedHours c in h,
+      cfRevenueShare = RationalFields (numerator $ _cRevenueShare c) (denominator $ _cRevenueShare c)
+    }
 
 -- | Project detail response for GET /projects/:pid/detail
 data ProjectDetailResponse = ProjectDetailResponse
   { pdrDetail :: ProjectDetail
   }
 
-instance ToJSON ProjectDetailResponse where
-  toJSON (ProjectDetailResponse detail) =
-    object
-      [ "project" .= projectToJSON (_pdProject detail),
-        "contributors" .= (M.elems $ fmap contributorToJSON (_pdContributors detail))
-      ]
+instance HasCodec ProjectDetailResponse where
+  codec =
+    object "ProjectDetailResponse" $
+      (\pf cs -> ProjectDetailResponse (ProjectDetail (fieldsToProject pf) (rebuildContributorMap cs)))
+        <$> requiredField' "project" AC..= (projectToFields . _pdProject . pdrDetail)
+        <*> requiredField' "contributors" AC..= (fmap contributorToFields . M.elems . _pdContributors . pdrDetail)
+    where
+      fieldsToProject pf =
+        Project
+          { _projectName = pfName pf,
+            _inceptionDate = pfInceptionDate pf,
+            _initiator = pfInitiator pf,
+            _depRules = DepreciationRules (pfDepf pf) Nothing
+          }
+      rebuildContributorMap :: [ContributorFields] -> M.Map UserId Contributor
+      rebuildContributorMap =
+        M.fromList . fmap (\cf -> (cfUserId cf, fieldsToContributor cf))
+      fieldsToContributor cf =
+        Contributor
+          { _cUserId = cfUserId cf,
+            _cHandle = UserName (cfUsername cf),
+            _cJoinedOn = cfJoinedOn cf,
+            _cLoggedHours = Hours (cfLoggedHours cf),
+            _cDepreciatedHours = Hours (cfDepreciatedHours cf),
+            _cRevenueShare = rfNumerator (cfRevenueShare cf) % rfDenominator (cfRevenueShare cf)
+          }
 
---------------------------------------------------------------------------------
--- JSON serialization helpers
---------------------------------------------------------------------------------
-
--- | Serialize a Project to JSON
-projectToJSON :: Project -> Value
-projectToJSON p =
-  object
-    [ "projectName" .= _projectName p,
-      "inceptionDate" .= _inceptionDate p,
-      "initiator" .= (let UserId u = _initiator p in UUID.toText u),
-      "depf" .= depfToJSON (_depf $ _depRules p)
-    ]
-
--- | Serialize a DepreciationFunction to JSON
-depfToJSON :: DepreciationFunction -> Value
-depfToJSON = \case
-  LinearDepreciation undep dep ->
-    object
-      [ "type" .= ("LinearDepreciation" :: Text),
-        "arguments" .= object ["undep" .= undep, "dep" .= dep]
-      ]
-
--- | Serialize a Contributor to JSON
-contributorToJSON :: Contributor -> Value
-contributorToJSON c =
-  object
-    [ "userId" .= _cUserId c,
-      "username" .= (let UserName n = _cHandle c in n),
-      "joinedOn" .= _cJoinedOn c,
-      "loggedHours" .= (let Hours h = _cLoggedHours c in h),
-      "depreciatedHours" .= (let Hours h = _cDepreciatedHours c in h),
-      "revenueShare"
-        .= object
-          [ "numerator" .= numerator (_cRevenueShare c),
-            "denominator" .= denominator (_cRevenueShare c)
-          ]
-    ]
+instance ToJSON ProjectDetailResponse where toJSON = toJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/Projects.hs
+++ b/api/src/Aftok/API/Projects.hs
@@ -39,6 +39,7 @@ where
 
 import Aftok.API.Auctions (ProjectAuctionsAPI)
 import Aftok.API.Billing (ProjectBillablesAPI)
+import Aftok.API.GitHub (GitHubProjectAPI)
 import Aftok.API.Codec ()
 import Aftok.API.Types ()
 import qualified Aftok.Currency.Zcash.Zip321 as Zip321
@@ -358,3 +359,5 @@ type SingleProjectAPI =
     :<|> "auctions" :> ProjectAuctionsAPI
     -- GET/POST /projects/:projectId/billables
     :<|> "billables" :> ProjectBillablesAPI
+    -- GitHub repo management
+    :<|> GitHubProjectAPI

--- a/api/src/Aftok/API/Session.hs
+++ b/api/src/Aftok/API/Session.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Session API types for the Aftok API.
 module Aftok.API.Session
@@ -14,8 +16,10 @@ module Aftok.API.Session
 where
 
 import Aftok.API.Auth (AuthenticatedUser, LoginRequest)
-import Data.Aeson (ToJSON (..), (.=))
-import qualified Data.Aeson as A
+import Aftok.API.Codec ()
+import Autodocodec (HasCodec (..), object, requiredField', (.=))
+import Autodocodec.Aeson (toJSONViaCodec)
+import Data.Aeson (ToJSON (..))
 import Servant.API
 import Servant.Auth.Server (SetCookie)
 
@@ -40,9 +44,11 @@ data LoginCheckResponse = LoginCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON LoginCheckResponse where
-  toJSON (LoginCheckResponse li user) =
-    A.object
-      [ "loggedIn" .= li,
-        "user" .= user
-      ]
+instance HasCodec LoginCheckResponse where
+  codec =
+    object "LoginCheckResponse" $
+      LoginCheckResponse
+        <$> requiredField' "loggedIn" .= loggedIn
+        <*> requiredField' "user" .= loginUser
+
+instance ToJSON LoginCheckResponse where toJSON = toJSONViaCodec

--- a/api/src/Aftok/API/Types.hs
+++ b/api/src/Aftok/API/Types.hs
@@ -6,11 +6,13 @@
 -- instances for ID types used in URL parameters and JSON responses.
 module Aftok.API.Types () where
 
+import Aftok.API.Codec ()
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
 import Aftok.Types (ProjectId (..), UserId (..))
-import Data.Aeson (FromJSON (..), ToJSON (..), withText)
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Time.Core (fromThyme, toThyme)
 import qualified Data.Time as Time
@@ -62,59 +64,23 @@ instance ToHttpApiData C.UTCTime where
   toUrlPiece = toUrlPiece . fromThyme
 
 --------------------------------------------------------------------------------
--- JSON instances for ID types
+-- JSON instances for ID types (codec-derived)
 --------------------------------------------------------------------------------
 
-instance ToJSON UserId where
-  toJSON (UserId u) = toJSON $ UUID.toText u
+instance ToJSON UserId where toJSON = toJSONViaCodec
+instance FromJSON UserId where parseJSON = parseJSONViaCodec
 
-instance FromJSON UserId where
-  parseJSON = withText "UserId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for UserId"
-      Just u -> pure $ UserId u
+instance ToJSON ProjectId where toJSON = toJSONViaCodec
+instance FromJSON ProjectId where parseJSON = parseJSONViaCodec
 
-instance ToJSON ProjectId where
-  toJSON (ProjectId u) = toJSON $ UUID.toText u
+instance ToJSON BillableId where toJSON = toJSONViaCodec
+instance FromJSON BillableId where parseJSON = parseJSONViaCodec
 
-instance FromJSON ProjectId where
-  parseJSON = withText "ProjectId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for ProjectId"
-      Just u -> pure $ ProjectId u
+instance ToJSON SubscriptionId where toJSON = toJSONViaCodec
+instance FromJSON SubscriptionId where parseJSON = parseJSONViaCodec
 
-instance ToJSON BillableId where
-  toJSON (BillableId u) = toJSON $ UUID.toText u
+instance ToJSON AuctionId where toJSON = toJSONViaCodec
+instance FromJSON AuctionId where parseJSON = parseJSONViaCodec
 
-instance FromJSON BillableId where
-  parseJSON = withText "BillableId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for BillableId"
-      Just u -> pure $ BillableId u
-
-instance ToJSON SubscriptionId where
-  toJSON (SubscriptionId u) = toJSON $ UUID.toText u
-
-instance FromJSON SubscriptionId where
-  parseJSON = withText "SubscriptionId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for SubscriptionId"
-      Just u -> pure $ SubscriptionId u
-
-instance ToJSON AuctionId where
-  toJSON (AuctionId u) = toJSON $ UUID.toText u
-
-instance FromJSON AuctionId where
-  parseJSON = withText "AuctionId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for AuctionId"
-      Just u -> pure $ AuctionId u
-
-instance ToJSON PaymentId where
-  toJSON (PaymentId u) = toJSON $ UUID.toText u
-
-instance FromJSON PaymentId where
-  parseJSON = withText "PaymentId" $ \t ->
-    case UUID.fromText t of
-      Nothing -> fail "Invalid UUID for PaymentId"
-      Just u -> pure $ PaymentId u
+instance ToJSON PaymentId where toJSON = toJSONViaCodec
+instance FromJSON PaymentId where parseJSON = parseJSONViaCodec

--- a/api/src/Aftok/API/Types.hs
+++ b/api/src/Aftok/API/Types.hs
@@ -10,7 +10,7 @@ import Aftok.API.Codec ()
 import Aftok.Auction (AuctionId (..))
 import Aftok.Billing (BillableId (..), SubscriptionId (..))
 import Aftok.Payments.Types (PaymentId (..))
-import Aftok.Types (ProjectId (..), UserId (..))
+import Aftok.Types (GitHubRepoLinkId (..), GitHubUsername (..), GitHubWebhookEventId (..), ProjectId (..), UserId (..))
 import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Thyme.Clock as C
@@ -84,3 +84,12 @@ instance FromJSON AuctionId where parseJSON = parseJSONViaCodec
 
 instance ToJSON PaymentId where toJSON = toJSONViaCodec
 instance FromJSON PaymentId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubRepoLinkId where toJSON = toJSONViaCodec
+instance FromJSON GitHubRepoLinkId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubWebhookEventId where toJSON = toJSONViaCodec
+instance FromJSON GitHubWebhookEventId where parseJSON = parseJSONViaCodec
+
+instance ToJSON GitHubUsername where toJSON = toJSONViaCodec
+instance FromJSON GitHubUsername where parseJSON = parseJSONViaCodec

--- a/api/src/Aftok/API/Users.hs
+++ b/api/src/Aftok/API/Users.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Users API types for the Aftok API.
 module Aftok.API.Users
@@ -34,6 +36,7 @@ module Aftok.API.Users
   )
 where
 
+import Aftok.API.Codec ()
 import Aftok.Project (InvitationCode, parseInvCode)
 import Aftok.Types
   ( Email (..),
@@ -41,13 +44,15 @@ import Aftok.Types
     UserId,
     UserName (..),
   )
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
 import Control.Lens (makeLenses)
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     (.:),
     (.:?),
-    (.=),
   )
 import qualified Data.Aeson as A
 import Servant.API
@@ -59,11 +64,17 @@ import Aftok.API.Types ()
 
 -- | Registration response
 data RegisterResponse = RegisterResponse
-  { userId :: UserId
+  { rrUserId :: UserId
   }
   deriving (Generic)
 
-instance ToJSON RegisterResponse
+instance HasCodec RegisterResponse where
+  codec =
+    object "RegisterResponse" $
+      RegisterResponse
+        <$> requiredField' "userId" AC..= rrUserId
+
+instance ToJSON RegisterResponse where toJSON = toJSONViaCodec
 
 -- | Address validation error
 data AddressInvalid = AddressInvalid
@@ -120,11 +131,11 @@ data RegisterError
 instance ToJSON RegisterError where
   toJSON = \case
     RegParseError msg ->
-      A.object ["parseError" .= msg]
+      A.object ["parseError" A..= msg]
     RegCaptchaError e ->
-      A.object ["captchaError" .= (show e :: Text)]
+      A.object ["captchaError" A..= (show e :: Text)]
     RegZAddrError zerr ->
-      A.object ["zaddrError" .= (show zerr :: Text)]
+      A.object ["zaddrError" A..= (show zerr :: Text)]
 
 -- | Username check response
 data UsernameCheckResponse = UsernameCheckResponse
@@ -133,7 +144,14 @@ data UsernameCheckResponse = UsernameCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON UsernameCheckResponse
+instance HasCodec UsernameCheckResponse where
+  codec =
+    object "UsernameCheckResponse" $
+      UsernameCheckResponse
+        <$> requiredField' "usernameAvailable" AC..= usernameAvailable
+        <*> optionalField' "usernameMessage" AC..= usernameMessage
+
+instance ToJSON UsernameCheckResponse where toJSON = toJSONViaCodec
 
 -- | Z-address check response
 data ZAddrCheckResponse = ZAddrCheckResponse
@@ -142,7 +160,14 @@ data ZAddrCheckResponse = ZAddrCheckResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON ZAddrCheckResponse
+instance HasCodec ZAddrCheckResponse where
+  codec =
+    object "ZAddrCheckResponse" $
+      ZAddrCheckResponse
+        <$> requiredField' "zaddrValid" AC..= zaddrValid
+        <*> optionalField' "zaddrMessage" AC..= zaddrMessage
+
+instance ToJSON ZAddrCheckResponse where toJSON = toJSONViaCodec
 
 -- | Captcha errors
 data CaptchaError
@@ -184,12 +209,14 @@ data AccountSettingsResponse = AccountSettingsResponse
   }
   deriving (Show, Eq, Generic)
 
-instance ToJSON AccountSettingsResponse where
-  toJSON (AccountSettingsResponse uname zaddr) =
-    A.object
-      [ "username" .= uname,
-        "zcashAddress" .= zaddr
-      ]
+instance HasCodec AccountSettingsResponse where
+  codec =
+    object "AccountSettingsResponse" $
+      AccountSettingsResponse
+        <$> requiredField' "username" AC..= asrUsername
+        <*> optionalField' "zcashAddress" AC..= asrZcashAddress
+
+instance ToJSON AccountSettingsResponse where toJSON = toJSONViaCodec
 
 -- | Set payment address request
 data SetPaymentAddressRequest = SetPaymentAddressRequest
@@ -197,10 +224,13 @@ data SetPaymentAddressRequest = SetPaymentAddressRequest
   }
   deriving (Show, Eq, Generic)
 
-instance FromJSON SetPaymentAddressRequest where
-  parseJSON (A.Object v) =
-    SetPaymentAddressRequest <$> v .: "zcashAddress"
-  parseJSON _ = mzero
+instance HasCodec SetPaymentAddressRequest where
+  codec =
+    object "SetPaymentAddressRequest" $
+      SetPaymentAddressRequest
+        <$> requiredField' "zcashAddress" AC..= sparZcashAddress
+
+instance FromJSON SetPaymentAddressRequest where parseJSON = parseJSONViaCodec
 
 --------------------------------------------------------------------------------
 -- API Types

--- a/api/src/Aftok/API/WorkLog.hs
+++ b/api/src/Aftok/API/WorkLog.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | WorkLog API types for the Aftok API.
 module Aftok.API.WorkLog
@@ -23,25 +25,22 @@ module Aftok.API.WorkLog
   )
 where
 
-import Aftok.Json (parseCreditToV2, creditToJSON)
-import Aftok.TimeLog (EventId (..), LogEvent (..), eventName, eventTime, AmendmentId (..))
+import Aftok.API.Codec ()
+import Aftok.Json (parseCreditToV2)
+import Aftok.TimeLog (EventId (..), LogEvent (..), AmendmentId (..))
 import Aftok.Types (CreditTo (..), ProjectId, UserId)
-import Control.Lens ((^.))
 import Data.Aeson
   ( FromJSON (..),
     ToJSON (..),
     Value (Object),
-    object,
     (.:),
-    (.:?),
-    (.=),
   )
-import Data.Aeson.Types (Pair)
 import qualified Data.Text as T
 import qualified Data.Thyme.Clock as C
 import Data.Thyme.Format.Aeson ()
-import Data.Aeson.Key (fromText)
-import qualified Data.UUID as UUID
+import qualified Autodocodec as AC
+import Autodocodec (HasCodec (..), object, optionalField', requiredField')
+import Autodocodec.Aeson (toJSONViaCodec, parseJSONViaCodec)
 import Servant.API
 import Aftok.API.Types ()
 
@@ -77,12 +76,14 @@ data LogStartRequest = LogStartRequest
   }
   deriving (Generic)
 
-instance FromJSON LogStartRequest where
-  parseJSON (Object o) = do
-    creditTo' <- o .:? "creditTo" >>= maybe (pure Nothing) (fmap Just . parseCreditToV2)
-    eventMeta' <- o .:? "eventMeta"
-    pure $ LogStartRequest creditTo' eventMeta'
-  parseJSON _ = mzero
+instance FromJSON LogStartRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec LogStartRequest where
+  codec =
+    object "LogStartRequest" $
+      LogStartRequest
+        <$> optionalField' "creditTo" AC..= lsrCreditTo
+        <*> optionalField' "eventMeta" AC..= lsrEventMeta
 
 -- | Log end request
 data LogEndRequest = LogEndRequest
@@ -91,12 +92,14 @@ data LogEndRequest = LogEndRequest
   }
   deriving (Generic)
 
-instance FromJSON LogEndRequest where
-  parseJSON (Object o) = do
-    creditTo' <- o .:? "creditTo" >>= maybe (pure Nothing) (fmap Just . parseCreditToV2)
-    eventMeta' <- o .:? "eventMeta"
-    pure $ LogEndRequest creditTo' eventMeta'
-  parseJSON _ = mzero
+instance FromJSON LogEndRequest where parseJSON = parseJSONViaCodec
+
+instance HasCodec LogEndRequest where
+  codec =
+    object "LogEndRequest" $
+      LogEndRequest
+        <$> optionalField' "creditTo" AC..= lerCreditTo
+        <*> optionalField' "eventMeta" AC..= lerEventMeta
 
 -- | Event amendment request
 data EventAmendmentRequest = EventAmendmentRequest
@@ -135,13 +138,18 @@ data ExtendedLogEntryResponse = ExtendedLogEntryResponse
     elrEventMeta :: Maybe Value
   }
 
-instance ToJSON ExtendedLogEntryResponse where
-  toJSON r =
-    object $
-      [ "projectId" .= elrProjectId r,
-        "loggedBy" .= elrLoggedBy r
-      ]
-        <> keyedLogEntryFields (elrEventId r) (elrCreditTo r) (elrEvent r) (elrEventMeta r)
+instance HasCodec ExtendedLogEntryResponse where
+  codec =
+    object "ExtendedLogEntryResponse" $
+      ExtendedLogEntryResponse
+        <$> requiredField' "projectId" AC..= elrProjectId
+        <*> requiredField' "loggedBy" AC..= elrLoggedBy
+        <*> requiredField' "eventId" AC..= elrEventId
+        <*> requiredField' "creditTo" AC..= elrCreditTo
+        <*> requiredField' "event" AC..= elrEvent
+        <*> requiredField' "eventMeta" AC..= elrEventMeta
+
+instance ToJSON ExtendedLogEntryResponse where toJSON = toJSONViaCodec
 
 -- | Response for events list items
 data KeyedLogEntryResponse = KeyedLogEntryResponse
@@ -151,17 +159,29 @@ data KeyedLogEntryResponse = KeyedLogEntryResponse
     klrEventMeta :: Maybe Value
   }
 
-instance ToJSON KeyedLogEntryResponse where
-  toJSON r =
-    object $ keyedLogEntryFields (klrEventId r) (klrCreditTo r) (klrEvent r) (klrEventMeta r)
+instance HasCodec KeyedLogEntryResponse where
+  codec =
+    object "KeyedLogEntryResponse" $
+      KeyedLogEntryResponse
+        <$> requiredField' "eventId" AC..= klrEventId
+        <*> requiredField' "creditTo" AC..= klrCreditTo
+        <*> requiredField' "event" AC..= klrEvent
+        <*> requiredField' "eventMeta" AC..= klrEventMeta
+
+instance ToJSON KeyedLogEntryResponse where toJSON = toJSONViaCodec
 
 -- | Work index response
 data WorkIndexResponse = WorkIndexResponse
   { wirWorkIndex :: [WorkIndexEntry]
   }
 
-instance ToJSON WorkIndexResponse where
-  toJSON r = object ["workIndex" .= wirWorkIndex r]
+instance HasCodec WorkIndexResponse where
+  codec =
+    object "WorkIndexResponse" $
+      WorkIndexResponse
+        <$> requiredField' "workIndex" AC..= wirWorkIndex
+
+instance ToJSON WorkIndexResponse where toJSON = toJSONViaCodec
 
 -- | Work index entry (per credit-to)
 data WorkIndexEntry = WorkIndexEntry
@@ -169,12 +189,14 @@ data WorkIndexEntry = WorkIndexEntry
     wieIntervals :: [IntervalResponse]
   }
 
-instance ToJSON WorkIndexEntry where
-  toJSON r =
-    object
-      [ "creditTo" .= creditToJSON (wieCreditTo r),
-        "intervals" .= wieIntervals r
-      ]
+instance HasCodec WorkIndexEntry where
+  codec =
+    object "WorkIndexEntry" $
+      WorkIndexEntry
+        <$> requiredField' "creditTo" AC..= wieCreditTo
+        <*> requiredField' "intervals" AC..= wieIntervals
+
+instance ToJSON WorkIndexEntry where toJSON = toJSONViaCodec
 
 -- | Interval in the work index
 data IntervalResponse = IntervalResponse
@@ -182,8 +204,14 @@ data IntervalResponse = IntervalResponse
     irEnd :: KeyedLogEntryResponse
   }
 
-instance ToJSON IntervalResponse where
-  toJSON r = object ["start" .= irStart r, "end" .= irEnd r]
+instance HasCodec IntervalResponse where
+  codec =
+    object "IntervalResponse" $
+      IntervalResponse
+        <$> requiredField' "start" AC..= irStart
+        <*> requiredField' "end" AC..= irEnd
+
+instance ToJSON IntervalResponse where toJSON = toJSONViaCodec
 
 -- | Event amendment result
 data AmendEventResponse = AmendEventResponse
@@ -191,27 +219,11 @@ data AmendEventResponse = AmendEventResponse
     aerAmendmentId :: AmendmentId
   }
 
-instance ToJSON AmendEventResponse where
-  toJSON r =
-    object
-      [ "replacement_event" .= (let EventId u = aerReplacementEvent r in UUID.toText u),
-        "amendment_id" .= (let AmendmentId u = aerAmendmentId r in UUID.toText u)
-      ]
+instance HasCodec AmendEventResponse where
+  codec =
+    object "AmendEventResponse" $
+      AmendEventResponse
+        <$> requiredField' "replacement_event" AC..= aerReplacementEvent
+        <*> requiredField' "amendment_id" AC..= aerAmendmentId
 
---------------------------------------------------------------------------------
--- Serialization Helpers
---------------------------------------------------------------------------------
-
--- | Serialize a log event to JSON
-logEventToJSON :: LogEvent -> Value
-logEventToJSON ev =
-  object [fromText (eventName ev) .= object ["eventTime" .= (ev ^. eventTime)]]
-
--- | Common fields for keyed log entries
-keyedLogEntryFields :: EventId -> CreditTo -> LogEvent -> Maybe Value -> [Pair]
-keyedLogEntryFields eid ct ev meta =
-  [ "eventId" .= (let EventId u = eid in UUID.toText u),
-    "creditTo" .= creditToJSON ct,
-    "event" .= logEventToJSON ev,
-    "eventMeta" .= meta
-  ]
+instance ToJSON AmendEventResponse where toJSON = toJSONViaCodec

--- a/core/aftok.cabal
+++ b/core/aftok.cabal
@@ -86,12 +86,14 @@ library
     Aftok.Currency.Zcash.Payments
     Aftok.Currency.Zcash.Zip321
     Aftok.Database
+    Aftok.GitHub
     Aftok.Database.PostgreSQL
     Aftok.Database.PostgreSQL.Json
     Aftok.Database.PostgreSQL.Types
     Aftok.Database.PostgreSQL.Auctions
     Aftok.Database.PostgreSQL.Billing
     Aftok.Database.PostgreSQL.Events
+    Aftok.Database.PostgreSQL.GitHub
     Aftok.Database.PostgreSQL.PasswordReset
     Aftok.Database.PostgreSQL.Projects
     Aftok.Database.PostgreSQL.Users

--- a/core/lib/Aftok/Database.hs
+++ b/core/lib/Aftok/Database.hs
@@ -32,9 +32,16 @@ import Aftok.TimeLog
   )
 import qualified Aftok.TimeLog as TL
 import Aftok.Password (PasswordHash)
+import Aftok.GitHub
+  ( GitHubRepoLink,
+    GitHubWebhookEvent,
+  )
 import Aftok.Types
   ( AccountId,
     Email,
+    GitHubRepoLinkId,
+    GitHubUsername,
+    GitHubWebhookEventId,
     PasswordResetToken,
     PasswordResetTokenId,
     ProjectId,
@@ -125,6 +132,17 @@ data DBOp a where
   -- Zcash address operations
   SetUserZcashAddress :: UserId -> Zcash.Address -> DBOp ()
   FindUserZcashAddress :: UserId -> DBOp (Maybe Zcash.Address)
+  -- GitHub integration operations
+  FindUserByGitHubUsername :: GitHubUsername -> DBOp (Maybe (UserId, User))
+  LinkGitHubUsername :: UserId -> GitHubUsername -> DBOp ()
+  UnlinkGitHubUsername :: UserId -> DBOp ()
+  GetUserGitHubUsername :: UserId -> DBOp (Maybe GitHubUsername)
+  CreateGitHubRepoLink :: GitHubRepoLink -> DBOp GitHubRepoLinkId
+  FindGitHubRepoLink :: Text -> Text -> DBOp (Maybe (GitHubRepoLinkId, GitHubRepoLink))
+  FindProjectGitHubRepoLinks :: ProjectId -> DBOp [(GitHubRepoLinkId, GitHubRepoLink)]
+  DeleteGitHubRepoLink :: GitHubRepoLinkId -> DBOp ()
+  RecordWebhookEvent :: GitHubRepoLinkId -> GitHubWebhookEvent -> DBOp GitHubWebhookEventId
+  IsDeliveryProcessed :: Text -> DBOp Bool
   RaiseDBError :: forall x y. DBError -> DBOp x -> DBOp y
 
 data InvitationError
@@ -376,6 +394,38 @@ findSubscriptionUnpaidRequests = liftdb . FindSubscriptionUnpaidRequests
 
 findPayment :: (MonadDB m) => Currency a c -> PaymentRequestId -> MaybeT m (Payment c)
 findPayment currency prid = MaybeT $ (fmap snd . headMay) <$> liftdb (FindPayments currency prid)
+
+-- GitHub integration ops
+
+findUserByGitHubUsername :: (MonadDB m) => GitHubUsername -> MaybeT m (UserId, User)
+findUserByGitHubUsername = MaybeT . liftdb . FindUserByGitHubUsername
+
+linkGitHubUsername :: (MonadDB m) => UserId -> GitHubUsername -> m ()
+linkGitHubUsername uid ghUser = liftdb $ LinkGitHubUsername uid ghUser
+
+unlinkGitHubUsername :: (MonadDB m) => UserId -> m ()
+unlinkGitHubUsername uid = liftdb $ UnlinkGitHubUsername uid
+
+getUserGitHubUsername :: (MonadDB m) => UserId -> m (Maybe GitHubUsername)
+getUserGitHubUsername = liftdb . GetUserGitHubUsername
+
+createGitHubRepoLink :: (MonadDB m) => GitHubRepoLink -> m GitHubRepoLinkId
+createGitHubRepoLink = liftdb . CreateGitHubRepoLink
+
+findGitHubRepoLink :: (MonadDB m) => Text -> Text -> MaybeT m (GitHubRepoLinkId, GitHubRepoLink)
+findGitHubRepoLink owner repo = MaybeT . liftdb $ FindGitHubRepoLink owner repo
+
+findProjectGitHubRepoLinks :: (MonadDB m) => ProjectId -> m [(GitHubRepoLinkId, GitHubRepoLink)]
+findProjectGitHubRepoLinks = liftdb . FindProjectGitHubRepoLinks
+
+deleteGitHubRepoLink :: (MonadDB m) => GitHubRepoLinkId -> m ()
+deleteGitHubRepoLink = liftdb . DeleteGitHubRepoLink
+
+recordWebhookEvent :: (MonadDB m) => GitHubRepoLinkId -> GitHubWebhookEvent -> m GitHubWebhookEventId
+recordWebhookEvent linkId ev = liftdb $ RecordWebhookEvent linkId ev
+
+isDeliveryProcessed :: (MonadDB m) => Text -> m Bool
+isDeliveryProcessed = liftdb . IsDeliveryProcessed
 
 -- Auction ops
 

--- a/core/lib/Aftok/Database/PostgreSQL.hs
+++ b/core/lib/Aftok/Database/PostgreSQL.hs
@@ -14,6 +14,7 @@ import Aftok.Database
 import qualified Aftok.Database.PostgreSQL.Auctions as Q
 import qualified Aftok.Database.PostgreSQL.Billing as Q
 import qualified Aftok.Database.PostgreSQL.Events as Q
+import qualified Aftok.Database.PostgreSQL.GitHub as Q
 import qualified Aftok.Database.PostgreSQL.PasswordReset as Q
 import qualified Aftok.Database.PostgreSQL.Projects as Q
 import qualified Aftok.Database.PostgreSQL.Users as Q
@@ -102,4 +103,15 @@ pgEval =
     -- Zcash address operations
     (SetUserZcashAddress uid addr) -> Q.setUserZcashAddress uid addr
     (FindUserZcashAddress uid) -> Q.findUserZcashAddress uid
+    -- GitHub integration operations
+    (FindUserByGitHubUsername ghUser) -> Q.findUserByGitHubUsername ghUser
+    (LinkGitHubUsername uid ghUser) -> Q.linkGitHubUsername uid ghUser
+    (UnlinkGitHubUsername uid) -> Q.unlinkGitHubUsername uid
+    (GetUserGitHubUsername uid) -> Q.getUserGitHubUsername uid
+    (CreateGitHubRepoLink link) -> Q.createGitHubRepoLink link
+    (FindGitHubRepoLink owner repo) -> Q.findGitHubRepoLink owner repo
+    (FindProjectGitHubRepoLinks pid) -> Q.findProjectGitHubRepoLinks pid
+    (DeleteGitHubRepoLink linkId) -> Q.deleteGitHubRepoLink linkId
+    (RecordWebhookEvent linkId ev) -> Q.recordWebhookEvent linkId ev
+    (IsDeliveryProcessed deliveryId) -> Q.isDeliveryProcessed deliveryId
     (RaiseDBError err _) -> lift . throwE $ err

--- a/core/lib/Aftok/Database/PostgreSQL/GitHub.hs
+++ b/core/lib/Aftok/Database/PostgreSQL/GitHub.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Aftok.Database.PostgreSQL.GitHub
+  ( -- * Repo link operations
+    createGitHubRepoLink,
+    findGitHubRepoLink,
+    findProjectGitHubRepoLinks,
+    deleteGitHubRepoLink,
+
+    -- * Webhook event tracking
+    recordWebhookEvent,
+    isDeliveryProcessed,
+  )
+where
+
+import Aftok.Database.PostgreSQL.Types
+  ( DBM,
+    idParser,
+    pexec,
+    pinsert,
+    pquery,
+    utcParser,
+  )
+import Aftok.GitHub
+  ( GitHubEventStatus (..),
+    GitHubRepoLink (..),
+    GitHubWebhookEvent (..),
+    repoLinkCreatedBy,
+    repoLinkOwner,
+    repoLinkProjectId,
+    repoLinkRepo,
+    repoLinkWebhookSecret,
+  )
+import Aftok.TimeLog (EventId (..))
+import Aftok.Types
+  ( GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    GitHubWebhookEventId (..),
+    ProjectId (..),
+    UserId (..),
+    _ProjectId,
+    _UserId,
+  )
+import Control.Lens ((^.))
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (fromThyme)
+import Database.PostgreSQL.Simple
+import Database.PostgreSQL.Simple.FromRow
+import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Safe (headMay)
+
+-- | Create a new GitHub repo link
+createGitHubRepoLink :: GitHubRepoLink -> DBM GitHubRepoLinkId
+createGitHubRepoLink link =
+  pinsert
+    GitHubRepoLinkId
+    [sql| INSERT INTO github_repo_links (project_id, github_owner, github_repo, webhook_secret, created_by)
+          VALUES (?, ?, ?, ?, ?) RETURNING id |]
+    ( link ^. repoLinkProjectId . _ProjectId,
+      link ^. repoLinkOwner,
+      link ^. repoLinkRepo,
+      link ^. repoLinkWebhookSecret,
+      link ^. repoLinkCreatedBy . _UserId
+    )
+
+-- | Find a GitHub repo link by owner/repo
+findGitHubRepoLink :: Text -> Text -> DBM (Maybe (GitHubRepoLinkId, GitHubRepoLink))
+findGitHubRepoLink owner repo =
+  headMay
+    <$> pquery
+      repoLinkParser
+      [sql| SELECT id, project_id, github_owner, github_repo, webhook_secret, created_by, created_at
+            FROM github_repo_links
+            WHERE github_owner = ? AND github_repo = ? |]
+      (owner, repo)
+
+-- | Find all GitHub repo links for a project
+findProjectGitHubRepoLinks :: ProjectId -> DBM [(GitHubRepoLinkId, GitHubRepoLink)]
+findProjectGitHubRepoLinks (ProjectId pid) =
+  pquery
+    repoLinkParser
+    [sql| SELECT id, project_id, github_owner, github_repo, webhook_secret, created_by, created_at
+          FROM github_repo_links
+          WHERE project_id = ? |]
+    (Only pid)
+
+-- | Delete a GitHub repo link
+deleteGitHubRepoLink :: GitHubRepoLinkId -> DBM ()
+deleteGitHubRepoLink (GitHubRepoLinkId linkId) =
+  void $
+    pexec
+      [sql| DELETE FROM github_repo_links WHERE id = ? |]
+      (Only linkId)
+
+-- | Parser for GitHubRepoLink rows
+repoLinkParser :: RowParser (GitHubRepoLinkId, GitHubRepoLink)
+repoLinkParser = do
+  linkId <- idParser GitHubRepoLinkId
+  projectId <- idParser ProjectId
+  owner <- field
+  repo <- field
+  secret <- field
+  createdBy <- idParser UserId
+  createdAt <- utcParser
+  pure
+    ( linkId,
+      GitHubRepoLink
+        { _repoLinkProjectId = projectId,
+          _repoLinkOwner = owner,
+          _repoLinkRepo = repo,
+          _repoLinkWebhookSecret = secret,
+          _repoLinkCreatedBy = createdBy,
+          _repoLinkCreatedAt = createdAt
+        }
+    )
+
+-- | Record a webhook event for auditing/idempotency
+recordWebhookEvent :: GitHubRepoLinkId -> GitHubWebhookEvent -> DBM GitHubWebhookEventId
+recordWebhookEvent (GitHubRepoLinkId linkId) ev =
+  pinsert
+    GitHubWebhookEventId
+    [sql| INSERT INTO github_webhook_events
+          (repo_link_id, github_delivery_id, event_type, pr_number, pr_author_email,
+           pr_author_github_login, time_spent_parsed, status, error_message,
+           work_event_id, user_id, user_created, received_at, processed_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?::github_event_status, ?, ?, ?, ?, ?, ?)
+          RETURNING id |]
+    ( linkId,
+      _webhookEventDeliveryId ev,
+      _webhookEventType ev,
+      _webhookEventPRNumber ev,
+      _webhookEventAuthorEmail ev,
+      fmap (\(GitHubUsername u) -> u) (_webhookEventAuthorLogin ev),
+      fmap (round . C.toSeconds' :: C.NominalDiffTime -> Int64) (_webhookEventTimeSpent ev),
+      statusToText (_webhookEventStatus ev),
+      _webhookEventErrorMessage ev,
+      fmap (\(EventId eid) -> eid) (_webhookEventWorkEventId ev),
+      fmap (\(UserId uid) -> uid) (_webhookEventUserId ev),
+      _webhookEventUserCreated ev,
+      fromThyme $ _webhookEventReceivedAt ev,
+      fmap fromThyme (_webhookEventProcessedAt ev)
+    )
+
+-- | Check if a delivery has already been processed
+isDeliveryProcessed :: Text -> DBM Bool
+isDeliveryProcessed deliveryId = do
+  results <-
+    pquery
+      (field :: RowParser Bool)
+      [sql| SELECT EXISTS(
+              SELECT 1 FROM github_webhook_events
+              WHERE github_delivery_id = ?
+            ) |]
+      (Only deliveryId)
+  pure $ fromMaybe False (headMay results)
+
+-- | Convert event status to database text representation
+statusToText :: GitHubEventStatus -> Text
+statusToText = \case
+  EventProcessed -> "processed"
+  EventSkipped -> "skipped"
+  EventError -> "error"

--- a/core/lib/Aftok/Database/PostgreSQL/Users.hs
+++ b/core/lib/Aftok/Database/PostgreSQL/Users.hs
@@ -16,6 +16,11 @@ module Aftok.Database.PostgreSQL.Users
     updateUserPassword,
     setUserZcashAddress,
     findUserZcashAddress,
+    -- GitHub username operations
+    findUserByGitHubUsername,
+    linkGitHubUsername,
+    unlinkGitHubUsername,
+    getUserGitHubUsername,
   )
 where
 
@@ -243,3 +248,40 @@ setUserZcashAddress uid addr = do
     Nothing ->
       -- Insert a new primary account row
       linkZcashAccount uid addr
+
+-- | Find a user by their linked GitHub username
+findUserByGitHubUsername :: GitHubUsername -> DBM (Maybe (UserId, User))
+findUserByGitHubUsername (GitHubUsername ghUser) = do
+  headMay
+    <$> pquery
+      ((,) <$> idParser UserId <*> userParser)
+      [sql| SELECT id, handle, recovery_email, recovery_zaddr
+            FROM users
+            WHERE github_username = ? |]
+      (Only ghUser)
+
+-- | Link a GitHub username to a user account
+linkGitHubUsername :: UserId -> GitHubUsername -> DBM ()
+linkGitHubUsername (UserId uid) (GitHubUsername ghUser) =
+  void $
+    pexec
+      [sql| UPDATE users SET github_username = ? WHERE id = ? |]
+      (ghUser, uid)
+
+-- | Unlink a GitHub username from a user account
+unlinkGitHubUsername :: UserId -> DBM ()
+unlinkGitHubUsername (UserId uid) =
+  void $
+    pexec
+      [sql| UPDATE users SET github_username = NULL WHERE id = ? |]
+      (Only uid)
+
+-- | Get the GitHub username linked to a user account
+getUserGitHubUsername :: UserId -> DBM (Maybe GitHubUsername)
+getUserGitHubUsername (UserId uid) = do
+  results <-
+    pquery
+      (fmap GitHubUsername <$> field)
+      [sql| SELECT github_username FROM users WHERE id = ? |]
+      (Only uid)
+  pure $ join (headMay results)

--- a/core/lib/Aftok/GitHub.hs
+++ b/core/lib/Aftok/GitHub.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Aftok.GitHub
+  ( -- * Types
+    GitHubRepoLink (..),
+    repoLinkProjectId,
+    repoLinkOwner,
+    repoLinkRepo,
+    repoLinkWebhookSecret,
+    repoLinkCreatedBy,
+    repoLinkCreatedAt,
+    GitHubEventStatus (..),
+    GitHubWebhookEvent (..),
+    webhookEventDeliveryId,
+    webhookEventType,
+    webhookEventPRNumber,
+    webhookEventAuthorEmail,
+    webhookEventAuthorLogin,
+    webhookEventTimeSpent,
+    webhookEventStatus,
+    webhookEventErrorMessage,
+    webhookEventWorkEventId,
+    webhookEventUserId,
+    webhookEventUserCreated,
+    webhookEventReceivedAt,
+    webhookEventProcessedAt,
+
+    -- * Duration parsing
+    Duration (..),
+    durationHours,
+    durationMinutes,
+    parseDuration,
+    parseTimeSpent,
+    durationToNDT,
+  )
+where
+
+import Aftok.TimeLog (EventId)
+import Aftok.Types
+  ( GitHubUsername (..),
+    ProjectId,
+    UserId,
+  )
+import Control.Lens (makeLenses)
+import Data.Attoparsec.Text as A
+import qualified Data.Char as Char
+import qualified Data.Text as T
+import qualified Data.Thyme.Clock as C
+
+-- | A link between a GitHub repository and an Aftok project
+data GitHubRepoLink = GitHubRepoLink
+  { _repoLinkProjectId :: !ProjectId,
+    _repoLinkOwner :: !Text,
+    _repoLinkRepo :: !Text,
+    _repoLinkWebhookSecret :: !Text,
+    _repoLinkCreatedBy :: !UserId,
+    _repoLinkCreatedAt :: !C.UTCTime
+  }
+  deriving (Show, Eq)
+
+makeLenses ''GitHubRepoLink
+
+-- | Status of a processed webhook event
+data GitHubEventStatus
+  = EventProcessed
+  | EventSkipped
+  | EventError
+  deriving (Show, Eq)
+
+-- | A record of a GitHub webhook event for auditing/idempotency
+data GitHubWebhookEvent = GitHubWebhookEvent
+  { _webhookEventDeliveryId :: !Text,
+    _webhookEventType :: !Text,
+    _webhookEventPRNumber :: !(Maybe Int),
+    _webhookEventAuthorEmail :: !(Maybe Text),
+    _webhookEventAuthorLogin :: !(Maybe GitHubUsername),
+    _webhookEventTimeSpent :: !(Maybe C.NominalDiffTime),
+    _webhookEventStatus :: !GitHubEventStatus,
+    _webhookEventErrorMessage :: !(Maybe Text),
+    _webhookEventWorkEventId :: !(Maybe EventId),
+    _webhookEventUserId :: !(Maybe UserId),
+    _webhookEventUserCreated :: !Bool,
+    _webhookEventReceivedAt :: !C.UTCTime,
+    _webhookEventProcessedAt :: !(Maybe C.UTCTime)
+  }
+  deriving (Show, Eq)
+
+makeLenses ''GitHubWebhookEvent
+
+-- | A duration in hours and minutes
+data Duration = Duration
+  { _durationHours :: !Int,
+    _durationMinutes :: !Int
+  }
+  deriving (Show, Eq)
+
+makeLenses ''Duration
+
+-- | Convert a Duration to NominalDiffTime
+durationToNDT :: Duration -> C.NominalDiffTime
+durationToNDT (Duration h m) = C.fromSeconds' $ toRational $ (h * 3600) + (m * 60)
+
+-- | Parse a duration string in various formats:
+-- - "2h30m", "2h 30m", "2h", "30m"
+-- - "2 hours 30 minutes", "2 hours", "30 minutes"
+-- - "2.5h", "2.5 hours"
+-- - "150m", "150 minutes"
+parseDuration :: Text -> Maybe Duration
+parseDuration input =
+  case parseOnly durationParser (T.strip $ T.toLower input) of
+    Right d -> Just d
+    Left _ -> Nothing
+
+-- | Parser for duration values
+durationParser :: Parser Duration
+durationParser =
+  hoursMinutesParser
+    <|> decimalHoursParser
+    <|> totalMinutesParser
+
+-- | Parse "2h30m", "2h 30m", "2 hours 30 minutes", etc.
+hoursMinutesParser :: Parser Duration
+hoursMinutesParser = do
+  h <- option 0 hoursComponent
+  skipSpace
+  m <- option 0 minutesComponent
+  endOfInput
+  if h == 0 && m == 0
+    then fail "Duration must be non-zero"
+    else pure $ Duration h m
+
+-- | Parse hours component: "2h", "2 hours", "2 hour"
+hoursComponent :: Parser Int
+hoursComponent = do
+  n <- decimal
+  skipSpace
+  _ <- string "h" <|> string "hours" <|> string "hour"
+  pure n
+
+-- | Parse minutes component: "30m", "30 minutes", "30 minute"
+minutesComponent :: Parser Int
+minutesComponent = do
+  n <- decimal
+  skipSpace
+  _ <- string "m" <|> string "minutes" <|> string "minute"
+  pure n
+
+-- | Parse decimal hours: "2.5h", "2.5 hours"
+decimalHoursParser :: Parser Duration
+decimalHoursParser = do
+  n <- double
+  skipSpace
+  _ <- string "h" <|> string "hours" <|> string "hour"
+  endOfInput
+  let totalMinutes = round (n * 60)
+      h = totalMinutes `div` 60
+      m = totalMinutes `mod` 60
+  pure $ Duration h m
+
+-- | Parse total minutes: "150m", "150 minutes"
+totalMinutesParser :: Parser Duration
+totalMinutesParser = do
+  n <- decimal
+  skipSpace
+  _ <- string "m" <|> string "minutes" <|> string "minute"
+  endOfInput
+  let h = n `div` 60
+      m = n `mod` 60
+  pure $ Duration h m
+
+-- | Extract "Time Spent: <duration>" from a PR body (case-insensitive)
+-- Returns the parsed duration if found
+parseTimeSpent :: Text -> Maybe Duration
+parseTimeSpent body =
+  let patterns = ["time spent:", "time-spent:", "timespent:"]
+   in case mapMaybe tryPattern patterns of
+        (d : _) -> Just d
+        [] -> Nothing
+  where
+    tryPattern pat =
+      let (_, after) = T.breakOn pat (T.toLower body)
+       in if T.null after
+            then Nothing
+            else
+              let -- Extract the duration text after the pattern
+                  afterPattern = T.drop (T.length pat) after
+                  -- Take characters until end of line or next whitespace block
+                  durationText = T.strip $ T.takeWhile (not . isEndOfDuration) $ T.dropWhile Char.isSpace afterPattern
+               in parseDuration durationText
+
+    isEndOfDuration c = c == '\n' || c == '\r'

--- a/core/lib/Aftok/Types.hs
+++ b/core/lib/Aftok/Types.hs
@@ -22,6 +22,10 @@ newtype Email = Email Text deriving (Show, Eq)
 
 makePrisms ''Email
 
+newtype GitHubUsername = GitHubUsername Text deriving (Show, Eq)
+
+makePrisms ''GitHubUsername
+
 data RecoverBy z
   = RecoverByEmail Email
   | RecoverByZAddr z
@@ -85,3 +89,12 @@ data DepreciationRules = DepreciationRules
   }
 
 makeLenses ''DepreciationRules
+
+-- GitHub integration types
+newtype GitHubRepoLinkId = GitHubRepoLinkId UUID deriving (Show, Eq, Ord)
+
+makePrisms ''GitHubRepoLinkId
+
+newtype GitHubWebhookEventId = GitHubWebhookEventId UUID deriving (Show, Eq, Ord)
+
+makePrisms ''GitHubWebhookEventId

--- a/executables/aftok-executables.cabal
+++ b/executables/aftok-executables.cabal
@@ -97,12 +97,15 @@ Executable aftok-server
     Aftok.Servant.WorkLog
     Aftok.Servant.Auctions
     Aftok.Servant.Billing
+    Aftok.Servant.GitHub
     Aftok.Servant.Payments
 
   build-depends:
     aftok,
     aftok-api,
+    base16-bytestring         >= 1.0 && < 1.1,
     directory                 >= 1.3.6,
+    memory                    >= 0.18 && < 0.19,
     http-client-tls           >= 0.3.6,
     jose                      >= 0.10 && < 0.12,
     resource-pool             >= 0.4 && < 0.5,

--- a/executables/server/Aftok/Servant/GitHub.hs
+++ b/executables/server/Aftok/Servant/GitHub.hs
@@ -1,0 +1,563 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Aftok.Servant.GitHub
+  ( -- * Handlers
+    gitHubWebhookServer,
+    gitHubProjectServer,
+    gitHubUserServer,
+  )
+where
+
+import Aftok.API.GitHub
+  ( GitHubProjectAPI,
+    GitHubUserAPI,
+    GitHubUsernameResponse (..),
+    GitHubWebhookAPI,
+    LinkGitHubUsernameRequest (..),
+    LinkRepoRequest (..),
+    LinkRepoResponse (..),
+    RepoLinkInfo (..),
+  )
+import Aftok.Database
+  ( addUserToProject,
+    createEvent,
+    createGitHubRepoLink,
+    createUser,
+    deleteGitHubRepoLink,
+    findGitHubRepoLink,
+    findProjectGitHubRepoLinks,
+    findUserByGitHubUsername,
+    findUserProjects,
+    getUserGitHubUsername,
+    isDeliveryProcessed,
+    linkGitHubUsername,
+    recordWebhookEvent,
+    unlinkGitHubUsername,
+  )
+import Aftok.GitHub
+  ( GitHubEventStatus (..),
+    GitHubRepoLink (..),
+    GitHubWebhookEvent (..),
+    durationToNDT,
+    parseTimeSpent,
+  )
+import Aftok.Servant.App (AppM, runDB)
+import Aftok.Servant.Auth (AuthenticatedUser (..))
+import Aftok.TimeLog
+  ( CreditTo (..),
+    LogEntry (..),
+    LogEvent (..),
+  )
+import Aftok.Types
+  ( Email (..),
+    GitHubRepoLinkId (..),
+    GitHubUsername (..),
+    ProjectId,
+    RecoverBy (..),
+    User (..),
+    UserId,
+    UserName (..),
+  )
+import Crypto.Hash (SHA256 (..))
+import Crypto.MAC.HMAC (HMAC (..), hmac)
+import Data.Aeson
+  ( Value (..),
+    (.=),
+  )
+import qualified Data.Aeson as A
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Thyme.Clock as C
+import Data.Thyme.Time.Core (toThyme)
+import qualified Data.Time as Time
+import Data.UUID (UUID)
+import Crypto.Random (getRandomBytes)
+import Servant
+import Servant.Auth.Server (AuthResult (..))
+
+--------------------------------------------------------------------------------
+-- Handlers
+--------------------------------------------------------------------------------
+
+-- | Webhook server (public, signature-verified)
+gitHubWebhookServer ::
+  ServerT GitHubWebhookAPI AppM
+gitHubWebhookServer mEventType mDeliveryId mSignature payload = do
+  -- Validate required headers
+  eventType <- maybe (throwError err400 {errBody = "Missing X-GitHub-Event header"}) pure mEventType
+  deliveryId <- maybe (throwError err400 {errBody = "Missing X-GitHub-Delivery header"}) pure mDeliveryId
+  signature <- maybe (throwError err400 {errBody = "Missing X-Hub-Signature-256 header"}) pure mSignature
+
+  -- Check idempotency - skip if already processed
+  alreadyProcessed <- runDB $ isDeliveryProcessed deliveryId
+  if alreadyProcessed || eventType /= "pull_request"
+    then pure NoContent
+    else processWebhook eventType deliveryId signature payload
+
+-- | Internal webhook processing (after basic validation)
+processWebhook :: Text -> Text -> Text -> Value -> AppM NoContent
+processWebhook eventType deliveryId signature payload = do
+  -- Extract repository info from payload
+  let mRepoInfo = do
+        obj <- case payload of
+          Object o -> Just o
+          _ -> Nothing
+        repo <- KM.lookup "repository" obj >>= \case
+          Object r -> Just r
+          _ -> Nothing
+        ownerObj <- KM.lookup "owner" repo >>= \case
+          Object o -> Just o
+          _ -> Nothing
+        ownerLogin <- KM.lookup "login" ownerObj >>= \case
+          String s -> Just s
+          _ -> Nothing
+        repoName <- KM.lookup "name" repo >>= \case
+          String s -> Just s
+          _ -> Nothing
+        pure (ownerLogin, repoName)
+
+  (owner, repo) <- maybe (throwError err400 {errBody = "Invalid payload structure"}) pure mRepoInfo
+
+  -- Find the repo link to verify signature
+  mRepoLink <- runDB $ runMaybeT $ findGitHubRepoLink owner repo
+  (repoLinkId, repoLink) <- maybe (throwError err404 {errBody = "Repository not linked to any project"}) pure mRepoLink
+
+  -- Verify HMAC signature
+  let secret = _repoLinkWebhookSecret repoLink
+      payloadBytes = toStrict $ A.encode payload
+  unless (verifySignature secret signature payloadBytes) $
+    throwError err401 {errBody = "Invalid signature"}
+
+  -- Process the webhook event
+  processWebhookEvent repoLinkId repoLink eventType deliveryId payload
+
+-- | Process a verified webhook event
+processWebhookEvent ::
+  GitHubRepoLinkId ->
+  GitHubRepoLink ->
+  Text ->
+  Text ->
+  Value ->
+  AppM NoContent
+processWebhookEvent repoLinkId repoLink _eventType deliveryId payload = do
+  now <- liftIO $ toThyme <$> Time.getCurrentTime
+
+  -- Extract PR info from payload
+  let extractPRInfo = do
+        obj <- case payload of
+          Object o -> Just o
+          _ -> Nothing
+        action <- KM.lookup "action" obj >>= \case
+          String s -> Just s
+          _ -> Nothing
+        pr <- KM.lookup "pull_request" obj >>= \case
+          Object p -> Just p
+          _ -> Nothing
+        merged <- KM.lookup "merged" pr >>= \case
+          Bool b -> Just b
+          _ -> Nothing
+        prNumber <- KM.lookup "number" pr >>= \case
+          Number n -> Just (round n :: Int)
+          _ -> Nothing
+        prBody <- KM.lookup "body" pr >>= \case
+          String s -> Just s
+          Null -> Just ""
+          _ -> Nothing
+        mergedAt <- KM.lookup "merged_at" pr >>= \case
+          String s -> parseISO8601 s
+          _ -> Nothing
+        prUrl <- KM.lookup "html_url" pr >>= \case
+          String s -> Just s
+          _ -> Nothing
+        prTitle <- KM.lookup "title" pr >>= \case
+          String s -> Just s
+          _ -> Nothing
+
+        -- Get merged_by info
+        mergedBy <- KM.lookup "merged_by" pr >>= \case
+          Object m -> Just m
+          _ -> Nothing
+        mergerLogin <- KM.lookup "login" mergedBy >>= \case
+          String s -> Just s
+          _ -> Nothing
+
+        -- Get author info from the user object
+        userObj <- KM.lookup "user" pr >>= \case
+          Object u -> Just u
+          _ -> Nothing
+        authorLogin <- KM.lookup "login" userObj >>= \case
+          String s -> Just s
+          _ -> Nothing
+
+        pure (action, merged, prNumber, prBody, mergedAt, prUrl, prTitle, mergerLogin, authorLogin)
+
+  case extractPRInfo of
+    Nothing -> do
+      -- Invalid payload, record and skip
+      let ev =
+            GitHubWebhookEvent
+              { _webhookEventDeliveryId = deliveryId,
+                _webhookEventType = "pull_request",
+                _webhookEventPRNumber = Nothing,
+                _webhookEventAuthorEmail = Nothing,
+                _webhookEventAuthorLogin = Nothing,
+                _webhookEventTimeSpent = Nothing,
+                _webhookEventStatus = EventSkipped,
+                _webhookEventErrorMessage = Just "Could not parse PR info from payload",
+                _webhookEventWorkEventId = Nothing,
+                _webhookEventUserId = Nothing,
+                _webhookEventUserCreated = False,
+                _webhookEventReceivedAt = now,
+                _webhookEventProcessedAt = Just now
+              }
+      runDB $ void $ recordWebhookEvent repoLinkId ev
+      pure NoContent
+    Just (action, merged, prNumber, prBody, mergedAt, prUrl, prTitle, mergerLogin, authorLogin) ->
+      -- Only process closed PRs that were merged
+      if not (action == "closed" && merged)
+        then do
+          let ev =
+                GitHubWebhookEvent
+                  { _webhookEventDeliveryId = deliveryId,
+                    _webhookEventType = "pull_request",
+                    _webhookEventPRNumber = Just prNumber,
+                    _webhookEventAuthorEmail = Nothing,
+                    _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                    _webhookEventTimeSpent = Nothing,
+                    _webhookEventStatus = EventSkipped,
+                    _webhookEventErrorMessage = Just $ "PR action=" <> action <> ", merged=" <> show merged,
+                    _webhookEventWorkEventId = Nothing,
+                    _webhookEventUserId = Nothing,
+                    _webhookEventUserCreated = False,
+                    _webhookEventReceivedAt = now,
+                    _webhookEventProcessedAt = Just now
+                  }
+          runDB $ void $ recordWebhookEvent repoLinkId ev
+          pure NoContent
+        else
+          -- Parse time spent from PR body
+          case parseTimeSpent prBody of
+        Nothing -> do
+          let ev =
+                GitHubWebhookEvent
+                  { _webhookEventDeliveryId = deliveryId,
+                    _webhookEventType = "pull_request",
+                    _webhookEventPRNumber = Just prNumber,
+                    _webhookEventAuthorEmail = Nothing,
+                    _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                    _webhookEventTimeSpent = Nothing,
+                    _webhookEventStatus = EventSkipped,
+                    _webhookEventErrorMessage = Just "No 'Time Spent:' found in PR body",
+                    _webhookEventWorkEventId = Nothing,
+                    _webhookEventUserId = Nothing,
+                    _webhookEventUserCreated = False,
+                    _webhookEventReceivedAt = now,
+                    _webhookEventProcessedAt = Just now
+                  }
+          runDB $ void $ recordWebhookEvent repoLinkId ev
+          pure NoContent
+        Just duration -> do
+          let projectId = _repoLinkProjectId repoLink
+              timeSpent = durationToNDT duration
+
+          -- Look up merger by GitHub username
+          mMerger <- runDB $ runMaybeT $ findUserByGitHubUsername (GitHubUsername mergerLogin)
+
+          -- Look up author by GitHub username
+          mAuthor <- runDB $ runMaybeT $ findUserByGitHubUsername (GitHubUsername authorLogin)
+
+          -- Determine if merger is project member and process accordingly
+          case mMerger of
+            Nothing -> do
+              -- Merger not linked to any account - check if author is a member
+              case mAuthor of
+                Just (authorUid, _) -> do
+                  -- Author is known, credit them
+                  createWorkEvents projectId authorUid timeSpent mergedAt prUrl prTitle prNumber now
+                  let ev =
+                        GitHubWebhookEvent
+                          { _webhookEventDeliveryId = deliveryId,
+                            _webhookEventType = "pull_request",
+                            _webhookEventPRNumber = Just prNumber,
+                            _webhookEventAuthorEmail = Nothing,
+                            _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                            _webhookEventTimeSpent = Just timeSpent,
+                            _webhookEventStatus = EventProcessed,
+                            _webhookEventErrorMessage = Nothing,
+                            _webhookEventWorkEventId = Nothing,
+                            _webhookEventUserId = Just authorUid,
+                            _webhookEventUserCreated = False,
+                            _webhookEventReceivedAt = now,
+                            _webhookEventProcessedAt = Just now
+                          }
+                  runDB $ void $ recordWebhookEvent repoLinkId ev
+                  pure NoContent
+                Nothing -> do
+                  -- Neither merger nor author is known - skip
+                  let ev =
+                        GitHubWebhookEvent
+                          { _webhookEventDeliveryId = deliveryId,
+                            _webhookEventType = "pull_request",
+                            _webhookEventPRNumber = Just prNumber,
+                            _webhookEventAuthorEmail = Nothing,
+                            _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                            _webhookEventTimeSpent = Just timeSpent,
+                            _webhookEventStatus = EventSkipped,
+                            _webhookEventErrorMessage = Just "Merger not project member and author not found",
+                            _webhookEventWorkEventId = Nothing,
+                            _webhookEventUserId = Nothing,
+                            _webhookEventUserCreated = False,
+                            _webhookEventReceivedAt = now,
+                            _webhookEventProcessedAt = Just now
+                          }
+                  runDB $ void $ recordWebhookEvent repoLinkId ev
+                  pure NoContent
+            Just (mergerUid, _) -> do
+              -- Merger is known, check if they're a project member
+              -- If author is known, credit them; otherwise create provisional user
+              case mAuthor of
+                Just (authorUid, _) -> do
+                  -- Author is known, credit them
+                  createWorkEvents projectId authorUid timeSpent mergedAt prUrl prTitle prNumber now
+                  let ev =
+                        GitHubWebhookEvent
+                          { _webhookEventDeliveryId = deliveryId,
+                            _webhookEventType = "pull_request",
+                            _webhookEventPRNumber = Just prNumber,
+                            _webhookEventAuthorEmail = Nothing,
+                            _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                            _webhookEventTimeSpent = Just timeSpent,
+                            _webhookEventStatus = EventProcessed,
+                            _webhookEventErrorMessage = Nothing,
+                            _webhookEventWorkEventId = Nothing,
+                            _webhookEventUserId = Just authorUid,
+                            _webhookEventUserCreated = False,
+                            _webhookEventReceivedAt = now,
+                            _webhookEventProcessedAt = Just now
+                          }
+                  runDB $ void $ recordWebhookEvent repoLinkId ev
+                  pure NoContent
+                Nothing -> do
+                  -- Author not found - create provisional user
+                  let provisionalUser =
+                        User
+                          { _username = UserName $ "github_" <> authorLogin,
+                            _userAccountRecovery = RecoverByEmail (Email $ authorLogin <> "@github.placeholder")
+                          }
+                  authorUid <- runDB $ createUser provisionalUser
+                  -- Link their GitHub username
+                  runDB $ linkGitHubUsername authorUid (GitHubUsername authorLogin)
+                  -- Add them to the project (merger must be a member)
+                  runDB $ addUserToProject projectId mergerUid authorUid
+                  -- Credit the work
+                  createWorkEvents projectId authorUid timeSpent mergedAt prUrl prTitle prNumber now
+                  let ev =
+                        GitHubWebhookEvent
+                          { _webhookEventDeliveryId = deliveryId,
+                            _webhookEventType = "pull_request",
+                            _webhookEventPRNumber = Just prNumber,
+                            _webhookEventAuthorEmail = Nothing,
+                            _webhookEventAuthorLogin = Just (GitHubUsername authorLogin),
+                            _webhookEventTimeSpent = Just timeSpent,
+                            _webhookEventStatus = EventProcessed,
+                            _webhookEventErrorMessage = Nothing,
+                            _webhookEventWorkEventId = Nothing,
+                            _webhookEventUserId = Just authorUid,
+                            _webhookEventUserCreated = True,
+                            _webhookEventReceivedAt = now,
+                            _webhookEventProcessedAt = Just now
+                          }
+                  runDB $ void $ recordWebhookEvent repoLinkId ev
+                  pure NoContent
+
+-- | Create StartWork and StopWork events for credited work
+createWorkEvents ::
+  ProjectId ->
+  UserId ->
+  C.NominalDiffTime ->
+  C.UTCTime ->
+  Text ->
+  Text ->
+  Int ->
+  C.UTCTime ->
+  AppM ()
+createWorkEvents projectId userId duration mergedAt prUrl prTitle prNumber _now = do
+  let endTime = mergedAt
+      startTime = C.addUTCTime (negate duration) endTime
+      metadata =
+        Just $
+          A.object
+            [ "source" .= ("github_pr" :: Text),
+              "pr_number" .= prNumber,
+              "pr_title" .= prTitle,
+              "pr_url" .= prUrl
+            ]
+      startEntry =
+        LogEntry
+          { _creditTo = CreditToUser userId,
+            _event = StartWork startTime,
+            _eventMeta = metadata
+          }
+      stopEntry =
+        LogEntry
+          { _creditTo = CreditToUser userId,
+            _event = StopWork endTime,
+            _eventMeta = metadata
+          }
+  -- Create both events
+  _ <- runDB $ createEvent projectId userId startEntry
+  _ <- runDB $ createEvent projectId userId stopEntry
+  pure ()
+
+-- | Verify HMAC-SHA256 signature
+verifySignature :: Text -> Text -> ByteString -> Bool
+verifySignature secret signature payload =
+  let secretBytes = T.encodeUtf8 secret
+      expectedSig = hmac secretBytes payload :: HMAC SHA256
+      expectedHex = "sha256=" <> T.decodeUtf8 (B16.encode $ BA.convert expectedSig)
+   in signature == expectedHex
+
+-- | Parse ISO8601 timestamp
+parseISO8601 :: Text -> Maybe C.UTCTime
+parseISO8601 t =
+  toThyme <$> Time.parseTimeM True Time.defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (T.unpack t)
+
+-- | Project-level GitHub management server (protected)
+gitHubProjectServer ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  ServerT GitHubProjectAPI AppM
+gitHubProjectServer authResult pid =
+  listRepoLinksHandler authResult pid
+    :<|> linkRepoHandler authResult pid
+    :<|> unlinkRepoHandler authResult pid
+
+-- | Check if user is a member of the project
+checkMembership :: UserId -> ProjectId -> AppM ()
+checkMembership uid pid = do
+  projects <- runDB $ findUserProjects uid
+  unless (any (\(p, _) -> p == pid) projects) $
+    throwError err403 {errBody = "User is not a member of this project"}
+
+-- | List all repos linked to a project
+listRepoLinksHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  AppM [RepoLinkInfo]
+listRepoLinksHandler (Authenticated user) pid = do
+  let uid = auUserId user
+  checkMembership uid pid
+  links <- runDB $ findProjectGitHubRepoLinks pid
+  pure $
+    fmap
+      ( \(rLinkId, link) ->
+          RepoLinkInfo
+            { rliId = rLinkId,
+              rliOwner = _repoLinkOwner link,
+              rliRepo = _repoLinkRepo link,
+              rliCreatedAt = _repoLinkCreatedAt link
+            }
+      )
+      links
+listRepoLinksHandler _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | Link a repo to a project
+linkRepoHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  LinkRepoRequest ->
+  AppM LinkRepoResponse
+linkRepoHandler (Authenticated user) pid req = do
+  let uid = auUserId user
+  checkMembership uid pid
+  now <- liftIO $ toThyme <$> Time.getCurrentTime
+
+  -- Generate a secure random webhook secret
+  secretBytes <- liftIO $ getRandomBytes 32
+  let secret = T.decodeUtf8 $ B16.encode (secretBytes :: ByteString)
+
+  let link =
+        GitHubRepoLink
+          { _repoLinkProjectId = pid,
+            _repoLinkOwner = lrrOwner req,
+            _repoLinkRepo = lrrRepo req,
+            _repoLinkWebhookSecret = secret,
+            _repoLinkCreatedBy = uid,
+            _repoLinkCreatedAt = now
+          }
+
+  newLinkId <- runDB $ createGitHubRepoLink link
+  pure $
+    LinkRepoResponse
+      { lrLinkId = newLinkId,
+        lrWebhookSecret = secret
+      }
+linkRepoHandler _ _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | Unlink a repo from a project
+unlinkRepoHandler ::
+  AuthResult AuthenticatedUser ->
+  ProjectId ->
+  UUID ->
+  AppM NoContent
+unlinkRepoHandler (Authenticated user) pid linkUUID = do
+  let uid = auUserId user
+      rLinkId = GitHubRepoLinkId linkUUID
+  checkMembership uid pid
+  runDB $ deleteGitHubRepoLink rLinkId
+  pure NoContent
+unlinkRepoHandler _ _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | User-level GitHub username linking server (protected)
+gitHubUserServer ::
+  AuthResult AuthenticatedUser ->
+  ServerT GitHubUserAPI AppM
+gitHubUserServer authResult =
+  getGitHubUsernameHandler authResult
+    :<|> linkGitHubUsernameHandler authResult
+    :<|> unlinkGitHubUsernameHandler authResult
+
+-- | Get the user's linked GitHub username
+getGitHubUsernameHandler ::
+  AuthResult AuthenticatedUser ->
+  AppM GitHubUsernameResponse
+getGitHubUsernameHandler (Authenticated user) = do
+  let uid = auUserId user
+  mUsername <- runDB $ getUserGitHubUsername uid
+  pure $ GitHubUsernameResponse $ fmap (\(GitHubUsername u) -> u) mUsername
+getGitHubUsernameHandler _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | Link a GitHub username to the user's account
+linkGitHubUsernameHandler ::
+  AuthResult AuthenticatedUser ->
+  LinkGitHubUsernameRequest ->
+  AppM NoContent
+linkGitHubUsernameHandler (Authenticated user) req = do
+  let uid = auUserId user
+      ghUsername = GitHubUsername (lgurUsername req)
+  runDB $ linkGitHubUsername uid ghUsername
+  pure NoContent
+linkGitHubUsernameHandler _ _ =
+  throwError err401 {errBody = "Authentication required"}
+
+-- | Unlink the GitHub username from the user's account
+unlinkGitHubUsernameHandler ::
+  AuthResult AuthenticatedUser ->
+  AppM NoContent
+unlinkGitHubUsernameHandler (Authenticated user) = do
+  let uid = auUserId user
+  runDB $ unlinkGitHubUsername uid
+  pure NoContent
+unlinkGitHubUsernameHandler _ =
+  throwError err401 {errBody = "Authentication required"}

--- a/executables/server/Aftok/Servant/Projects.hs
+++ b/executables/server/Aftok/Servant/Projects.hs
@@ -90,6 +90,7 @@ import Aftok.Servant.App (AppM, envConfig, runDB)
 import Aftok.Servant.Auth (AuthenticatedUser (..))
 import qualified Aftok.Servant.Auctions as Auctions
 import qualified Aftok.Servant.Billing as Billing
+import qualified Aftok.Servant.GitHub as GitHub
 import Aftok.API.WorkLog
   ( IntervalResponse (..),
     KeyedLogEntryResponse (..),
@@ -174,6 +175,7 @@ singleProjectServer payCfg authResult pid =
     :<|> projectInviteHandler authResult pid
     :<|> Auctions.projectAuctionsServer authResult pid
     :<|> Billing.projectBillablesServer payCfg authResult pid
+    :<|> GitHub.gitHubProjectServer authResult pid
 
 -- | List all projects for the authenticated user
 projectListHandler :: AuthResult AuthenticatedUser -> AppM [ProjectSummary]

--- a/executables/server/Aftok/Servant/Server.hs
+++ b/executables/server/Aftok/Servant/Server.hs
@@ -31,6 +31,14 @@ import Aftok.Servant.Billing
   ( ProtectedBillingAPI,
     protectedBillingServer,
   )
+import Aftok.Servant.GitHub
+  ( gitHubUserServer,
+    gitHubWebhookServer,
+  )
+import Aftok.API.GitHub
+  ( GitHubUserAPI,
+    GitHubWebhookAPI,
+  )
 import Aftok.Servant.Payments
   ( ProtectedPaymentsAPI,
     protectedPaymentsServer,
@@ -122,6 +130,7 @@ type ProtectedAPI =
     :<|> ProtectedPaymentsAPI
     :<|> ProtectedUsersAPI
     :<|> ProtectedSessionAPI
+    :<|> "user" :> GitHubUserAPI
 
 -- | API server (without static files)
 apiServer ::
@@ -130,12 +139,13 @@ apiServer ::
   RegisterOps IO ->
   CaptchaConfig ->
   PasswordResetOps IO ->
-  ServerT (UsersAPI :<|> SessionAPI :<|> PasswordResetAPI :<|> ConfigAPI :<|> AftokAuth :> ProtectedAPI) AppM
+  ServerT (UsersAPI :<|> SessionAPI :<|> PasswordResetAPI :<|> ConfigAPI :<|> GitHubWebhookAPI :<|> AftokAuth :> ProtectedAPI) AppM
 apiServer btcCfg payCfg regOps captchaCfg pwResetOps =
   usersServer regOps captchaCfg
     :<|> sessionServer
     :<|> passwordResetServer pwResetOps
     :<|> configServer captchaCfg
+    :<|> gitHubWebhookServer
     :<|> protectedServer btcCfg payCfg regOps
 
 -- | Protected server (requires authentication)
@@ -153,6 +163,7 @@ protectedServer btcCfg payCfg regOps authResult =
     :<|> protectedPaymentsServer btcCfg payCfg authResult
     :<|> protectedUsersServer regOps authResult
     :<|> protectedSessionServer authResult
+    :<|> gitHubUserServer authResult
 
 -- | Protected users server
 protectedUsersServer ::

--- a/migrations/2026-02-08_12-00-00_users-github-username.txt
+++ b/migrations/2026-02-08_12-00-00_users-github-username.txt
@@ -1,0 +1,10 @@
+Description: Add github_username column to users table for GitHub account linking
+Created: 2026-02-08 12:00:00 UTC
+Depends: 2026-02-07_00-00-00_address-change-events
+Apply: |
+  ALTER TABLE users ADD COLUMN github_username text UNIQUE;
+  CREATE INDEX idx_users_github_username ON users(github_username) WHERE github_username IS NOT NULL;
+
+Revert: |
+  DROP INDEX idx_users_github_username;
+  ALTER TABLE users DROP COLUMN github_username;

--- a/migrations/2026-02-08_12-00-01_github-repo-links.txt
+++ b/migrations/2026-02-08_12-00-01_github-repo-links.txt
@@ -1,0 +1,19 @@
+Description: Add github_repo_links table to link GitHub repositories to projects
+Created: 2026-02-08 12:00:01 UTC
+Depends: 2026-02-08_12-00-00_users-github-username
+Apply: |
+  CREATE TABLE github_repo_links (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    github_owner text NOT NULL,
+    github_repo text NOT NULL,
+    webhook_secret text NOT NULL,
+    created_by uuid NOT NULL REFERENCES users(id),
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    UNIQUE (github_owner, github_repo)
+  );
+
+  CREATE INDEX idx_github_repo_links_project_id ON github_repo_links(project_id);
+
+Revert: |
+  DROP TABLE github_repo_links;

--- a/migrations/2026-02-08_12-00-02_github-webhook-events.txt
+++ b/migrations/2026-02-08_12-00-02_github-webhook-events.txt
@@ -1,0 +1,30 @@
+Description: Add github_webhook_events table for audit logging of webhook processing
+Created: 2026-02-08 12:00:02 UTC
+Depends: 2026-02-08_12-00-01_github-repo-links
+Apply: |
+  CREATE TYPE github_event_status AS ENUM ('processed', 'skipped', 'error');
+
+  CREATE TABLE github_webhook_events (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    repo_link_id uuid NOT NULL REFERENCES github_repo_links(id) ON DELETE CASCADE,
+    github_delivery_id text NOT NULL UNIQUE,
+    event_type text NOT NULL,
+    pr_number integer,
+    pr_author_email text,
+    pr_author_github_login text,
+    time_spent_parsed interval,
+    status github_event_status NOT NULL,
+    error_message text,
+    work_event_id uuid REFERENCES work_events(id),
+    user_id uuid REFERENCES users(id),
+    user_created boolean NOT NULL DEFAULT false,
+    received_at timestamp with time zone NOT NULL DEFAULT now(),
+    processed_at timestamp with time zone
+  );
+
+  CREATE INDEX idx_github_webhook_events_repo_link_id ON github_webhook_events(repo_link_id);
+  CREATE INDEX idx_github_webhook_events_delivery_id ON github_webhook_events(github_delivery_id);
+
+Revert: |
+  DROP TABLE github_webhook_events;
+  DROP TYPE github_event_status;


### PR DESCRIPTION
When a PR with "Time Spent: <duration>" in its description is merged, the system automatically credits work time to the PR author. Supports duration formats like "2h30m", "2 hours", "2.5h", "150m".

Key features:
- Webhook endpoint with HMAC-SHA256 signature verification
- Links GitHub repos to Aftok projects with per-repo secrets
- Resolves users by linked GitHub username
- Creates provisional users for unknown authors when merger is a project member
- Audit logging of all webhook events for debugging/idempotency

API endpoints:
- POST /api/webhooks/github (public, signature-verified)
- GET/POST/DELETE /api/projects/:id/github/repos (manage repo links)
- GET/PUT/DELETE /api/user/github (link/unlink GitHub username)